### PR TITLE
Alex input updates

### DIFF
--- a/msr/msfr/steady/run_ns_initial.i
+++ b/msr/msfr/steady/run_ns_initial.i
@@ -5,9 +5,6 @@
 ## viscosity.                                                                 ##
 ################################################################################
 
-advected_interp_method='upwind'
-velocity_interp_method='rc'
-
 # Material properties
 rho = 4284  # density [kg / m^3]  (@1000K)
 mu = 0.0166 # viscosity [Pa s]
@@ -26,11 +23,12 @@ pump_force = -20000. # [N / m^3]
   v = v_y
   pressure = pressure
 
-  vel = 'velocity'
-  advected_interp_method = ${advected_interp_method}
-  velocity_interp_method = ${velocity_interp_method}
+  rhie_chow_user_object = 'rc'
+  advected_interp_method = 'upwind'
+  velocity_interp_method = 'rc'
   mu = 'mu'
   rho = ${rho}
+  mixing_length = 'mixing_len'
 []
 
 ################################################################################
@@ -49,6 +47,11 @@ pump_force = -20000. # [N / m^3]
     input = fmg
     new_sideset_name = min_core_radius
     normal = '0 1 0'
+  []
+  [delete_unused]
+    type = BlockDeletionGenerator
+    input = min_radius
+    block = 'shield reflector'
   []
 []
 
@@ -88,10 +91,10 @@ pump_force = -20000. # [N / m^3]
     #initial_from_file_var = lambda
   []
 []
+
 [AuxVariables]
   [mixing_len]
     type = MooseVariableFVReal
-    #initial_from_file_var = mixing_len
   []
   [wall_shear_stress]
     type = MooseVariableFVReal
@@ -101,7 +104,13 @@ pump_force = -20000. # [N / m^3]
   []
   [eddy_viscosity]
     type = MooseVariableFVReal
-    #initial_from_file_var = eddy_viscosity
+  []
+[]
+
+[UserObjects]
+  [rc]
+    type = INSFVRhieChowInterpolator
+    block = 'fuel pump hx'
   []
 []
 
@@ -121,24 +130,24 @@ pump_force = -20000. # [N / m^3]
   [u_time]
     type = INSFVMomentumTimeDerivative
     variable = v_x
+    momentum_component = 'x'
   []
   [u_advection]
     type = INSFVMomentumAdvection
     variable = v_x
-    advected_quantity = 'rhou'
     block = 'fuel pump hx'
+    momentum_component = 'x'
   []
   [u_turbulent_diffusion_rans]
     type = INSFVMixingLengthReynoldsStress
     variable = v_x
-    mixing_length = mixing_len
     momentum_component = 'x'
   []
   [u_molecular_diffusion]
-    type = FVDiffusion
+    type = INSFVMomentumDiffusion
     variable = v_x
-    coeff = 'mu'
     block = 'fuel pump hx'
+    momentum_component = 'x'
   []
   [u_pressure]
     type = INSFVMomentumPressure
@@ -150,25 +159,25 @@ pump_force = -20000. # [N / m^3]
   [v_time]
     type = INSFVMomentumTimeDerivative
     variable = v_y
+    momentum_component = 'y'
   []
   [v_advection]
     type = INSFVMomentumAdvection
     variable = v_y
-    advected_quantity = 'rhov'
     block = 'fuel pump hx'
+    momentum_component = 'y'
   []
   [v_turbulent_diffusion_rans]
     type = INSFVMixingLengthReynoldsStress
     variable = v_y
     rho = ${rho}
-    mixing_length = mixing_len
     momentum_component = 'y'
   []
   [v_molecular_diffusion]
-    type = FVDiffusion
+    type = INSFVMomentumDiffusion
     variable = v_y
-    coeff = 'mu'
     block = 'fuel pump hx'
+    momentum_component = 'y'
   []
   [v_pressure]
     type = INSFVMomentumPressure
@@ -176,18 +185,20 @@ pump_force = -20000. # [N / m^3]
     momentum_component = 'y'
     block = 'fuel pump hx'
   []
-  # [v_gravity]
-  #   type = FVBodyForce
-  #   variable = v_y
-  #   value = ${fparse -9.81 * rho}
-  #   block = 'fuel pump hx'
-  # []
+  [v_gravity]
+   type = INSFVMomentumGravity
+   variable = v_y
+   gravity = '0 -9.81 0'
+   block = 'fuel pump hx'
+   momentum_component = 'y'
+  []
 
   [pump]
-    type = FVBodyForce
+    type = INSFVBodyForce
     variable = v_y
-    value = ${pump_force}
+    functor = ${pump_force}
     block = 'pump'
+    momentum_component = 'y'
   []
 
   [friction_hx_x]
@@ -195,12 +206,14 @@ pump_force = -20000. # [N / m^3]
     variable = v_x
     quadratic_coef_name = 'friction_coef'
     block = 'hx'
+    momentum_component = 'x'
   []
   [friction_hx_y]
     type = INSFVMomentumFriction
     variable = v_y
     quadratic_coef_name = 'friction_coef'
     block = 'hx'
+    momentum_component = 'y'
   []
 []
 
@@ -231,7 +244,6 @@ pump_force = -20000. # [N / m^3]
   [turbulent_viscosity]
     type = INSFVMixingLengthTurbulentViscosityAux
     variable = eddy_viscosity
-    mixing_length = mixing_len
     block = 'fuel pump hx'
   []
 []
@@ -242,8 +254,8 @@ pump_force = -20000. # [N / m^3]
 
 [FVBCs]
   [walls_u]
-    type = INSFVWallFunctionBC    #rethink if we should put noslip just for the hx and pump.For this I need
-    variable = v_x                #an intersection between shield_walls, reflector_walls and hx and pump.
+    type = INSFVWallFunctionBC
+    variable = v_x
     boundary = 'shield_wall reflector_wall'
     momentum_component = x
   []
@@ -308,7 +320,6 @@ pump_force = -20000. # [N / m^3]
   []
   [total_viscosity]
     type = MixingLengthTurbulentViscosityMaterial
-    mixing_length = mixing_len
     mu = 'mu'
     block = 'fuel pump hx'
   []
@@ -316,12 +327,12 @@ pump_force = -20000. # [N / m^3]
     type = INSFVMaterial
     block = 'fuel pump hx'
   []
-  [not_used]
-    type = ADGenericFunctorMaterial
-    prop_names = 'not_used'
-    prop_values = 0
-    block = 'shield reflector'
-  []
+  #[not_used]
+  #  type = ADGenericFunctorMaterial
+  #  prop_names = 'not_used'
+  #  prop_values = 0
+  #  block = 'shield reflector'
+  #[]
   [friction]
     type = ADGenericFunctorMaterial
     prop_names = 'friction_coef'
@@ -334,21 +345,6 @@ pump_force = -20000. # [N / m^3]
 # EXECUTION / SOLVE
 ################################################################################
 
-[Preconditioning]
-  [SMP]
-    type = SMP
-    full = true
-  []
-[]
-
-[Functions]
-  [dts]
-    type = PiecewiseConstant
-    x = '0   0.4 0.8 1   2.2 4.0  4.3 5   8.8 9.2 9.8'
-    y = '0.2 0.4 0.2 0.4 0.1 0.05 0.1 0.2 0.4 0.8 2'
-  []
-[]
-
 [Executioner]
   type = Transient
 
@@ -357,15 +353,16 @@ pump_force = -20000. # [N / m^3]
   end_time = 15
 
   [TimeStepper]
-    type = FunctionDT
-    function = dts
+    type = IterationAdaptiveDT
+    optimal_iterations = 10
+    dt = 0.3
+    timestep_limiting_postprocessor = 1
   []
-  timestep_tolerance = 1e-13 # to avoid round off errors
 
   # Solver parameters
   solve_type = 'NEWTON'
-  petsc_options_iname = '-pc_type -ksp_gmres_restart'
-  petsc_options_value = 'lu 50'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -ksp_gmres_restart'
+  petsc_options_value = 'lu NONZERO 50'
   line_search = 'none'
   nl_rel_tol = 1e-12
   nl_abs_tol = 1e-6
@@ -403,6 +400,5 @@ pump_force = -20000. # [N / m^3]
     vel_x = v_x
     vel_y = v_y
     advected_mat_prop = ${rho}
-    fv = false # see MOOSE #18817
   []
 []

--- a/msr/msfr/transient/run_neutronics.i
+++ b/msr/msfr/transient/run_neutronics.i
@@ -25,7 +25,7 @@
   particle = neutron
   equation_type = transient
   restart_transport_system = true
-  scaling_eigenkernels = 1.0233728934387
+  scaling_eigenkernels = 1.0229660701716
 
   G = 6
 

--- a/pbfhr/steady/ss1_combined.i
+++ b/pbfhr/steady/ss1_combined.i
@@ -167,8 +167,6 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
   [rc]
     type = PINSFVRhieChowInterpolator
     block = ${blocks_fluid}
-    standard_body_forces = true
-    # smoothing_layers = 10
   []
 []
 
@@ -702,8 +700,8 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
   type = Transient
 
   solve_type = 'NEWTON'
-  petsc_options_iname = '-pc_type -sub_pc_type -sub_pc_factor_shift_type -ksp_gmres_restart'
-  petsc_options_value = 'asm      lu           NONZERO                   200'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
   line_search = 'none'
 
   # Iterations parameters
@@ -723,7 +721,7 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
 
   [TimeStepper]
     type = IterationAdaptiveDT
-    dt                 = 1
+    dt                 = 1e-2
     cutback_factor     = 0.5
     growth_factor      = 2.0
   []

--- a/pbfhr/steady/ss1_combined.i
+++ b/pbfhr/steady/ss1_combined.i
@@ -154,7 +154,15 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
   superficial_vel_x = 'vel_x'
   superficial_vel_y = 'vel_y'
 
+  rhie_chow_user_object = rc
   two_term_boundary_expansion = true
+[]
+
+[UserObjects]
+  [rc]
+    type = PINSFVRhieChowInterpolator
+    #standard_body_forces = true
+  []
 []
 
 [Debug]
@@ -206,15 +214,18 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
   [vel_x_time]
     type = PINSFVMomentumTimeDerivative
     variable = vel_x
+    momentum_component = x
   []
   [vel_x_advection]
     type = PINSFVMomentumAdvection
     variable = vel_x
     advected_quantity = 'superficial_rho_u'
+    momentum_component = x
   []
   [vel_x_viscosity]
     type = PINSFVMomentumDiffusion
     variable = vel_x
+    momentum_component = x
   []
   [u_pressure]
     type = PINSFVMomentumPressure
@@ -233,15 +244,18 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
   [vel_y_time]
     type = PINSFVMomentumTimeDerivative
     variable = vel_y
+    momentum_component = y
   []
   [vel_y_advection]
     type = PINSFVMomentumAdvection
     variable = vel_y
     advected_quantity = 'superficial_rho_v'
+    momentum_component = y
   []
   [vel_y_viscosity]
     type = PINSFVMomentumDiffusion
     variable = vel_y
+    momentum_component = y
   []
   [v_pressure]
     type = PINSFVMomentumPressure
@@ -468,11 +482,13 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
     type = INSFVNaturalFreeSlipBC
     boundary = 'bed_left barrel_wall'
     variable = vel_x
+    momentum_component = x
   []
   [free-slip-wall-y]
     type = INSFVNaturalFreeSlipBC
     boundary = 'bed_left barrel_wall'
     variable = vel_y
+    momentum_component = y
   []
 
   [outer]
@@ -731,31 +747,31 @@ power_density = ${fparse total_power / model_vol / 258 * 236}  # adjusted using 
 # ==============================================================================
 # MULTIAPPS FOR PEBBLE MODEL
 # ==============================================================================
-[MultiApps]
-  [coarse_mesh]
-    type = TransientMultiApp
-    execute_on = 'TIMESTEP_END'
-    input_files = 'ss3_coarse_pebble_mesh.i'
-    cli_args = 'Outputs/console=false'
-  []
-[]
+#[MultiApps]
+#  [coarse_mesh]
+#    type = TransientMultiApp
+#    execute_on = 'TIMESTEP_END'
+#    input_files = 'ss3_coarse_pebble_mesh.i'
+#    cli_args = 'Outputs/console=false'
+#  []
+#[]
 
-[Transfers]
-  [fuel_matrix_heat_source]
-    type = MultiAppProjectionTransfer
-    direction = to_multiapp
-    multi_app = coarse_mesh
-    source_variable = power_distribution
-    variable = power_distribution
-  []
-  [pebble_surface_temp]
-    type = MultiAppProjectionTransfer
-    direction = to_multiapp
-    multi_app = coarse_mesh
-    source_variable = temp_solid
-    variable = temp_solid
-  []
-[]
+#[Transfers]
+#  [fuel_matrix_heat_source]
+#    type = MultiAppProjectionTransfer
+#    direction = to_multiapp
+#    multi_app = coarse_mesh
+#    source_variable = power_distribution
+#    variable = power_distribution
+#  []
+#  [pebble_surface_temp]
+#    type = MultiAppProjectionTransfer
+#    direction = to_multiapp
+#    multi_app = coarse_mesh
+#    source_variable = temp_solid
+#    variable = temp_solid
+#  []
+#[]
 
 # ==============================================================================
 # POSTPROCESSORS DEBUG AND OUTPUTS


### PR DESCRIPTION
I uncommented the block deletion generation in order to be sure that my
new changes I just pushed to the interpolator PR work. Before my newest
commit on the interpolator PR this input would finish residual
evaluation when the blocks were deleted but would fail if the blocks
were not deleted. I also added block restriction to all the FV kernels;
we should probably add an integrity check in MOOSE to make sure that
kernel block restriction is always a subset of variable block
restriction.

Finally, the change that is important to get the nonlinear solve to
converge is to add the `-pc_factor_shift_type NONZERO` flag