### PR TITLE
Adding a VTB template

### DIFF
--- a/doc/content/contributing.md
+++ b/doc/content/contributing.md
@@ -1,7 +1,8 @@
 # Contribution guidelines
 
 The Virtual Test Bed welcomes contributions in advanced nuclear reactor modeling from all horizons,
-including, but not limited to, regulatory, industrial and academic institutions.
+including, but not limited to, regulatory, industrial and academic institutions. 
+[A VTB model template](template.md) is provided to facilitate the documentation. 
 
 ## Minimum viable contribution
 

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -117,7 +117,7 @@ Description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 ### Other key model details to provide in the high-level summary style=font-size:125%
 
-- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please click here to see the checklist, this can be used for the VTB team to categorize/sort the model)
+- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please [click here](https://mooseframework.inl.gov/virtual_test_bed/resources/codes_used.html) to see the checklist, this can be used for the VTB team to categorize/sort the model)
 
 - Type of simulation: e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state
 

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -117,15 +117,16 @@ Description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 ### Other key model details to provide in the high-level summary style=font-size:125%
 
-- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. 
+- Reactor Type(s): e.g., Liquid Metal Cooled Fast Reactor
 
 - Type of simulation: e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state
 
-- Non-MOOSE Based NEAMS Code Used: MC2-3, Nek5000/RS, etc. 
+- NEAMS MOOSE Codes Used: Griffin, Heat Conduction, Cardinal, etc. 
 
-- External Code (non-NEAMS based) Used: Cubit, OpenFOAM, etc.
+- NEAMS non-MOOSE Codes Used: MC2-3, Nek5000/RS, etc. 
 
-- Reactor Category(s): e.g., Liquid Metal Cooled Fast Reactor
+- Non-NEAMS Codes Used: Cubit, OpenFOAM, etc.
+
 
 !alert note
 More information is available online about [the list of NEAMS codes](https://neams.inl.gov/code-descriptions/) and the codes that have been used for [the models available in VTB repository](https://mooseframework.inl.gov/virtual_test_bed/resources/codes_used.html). 

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -105,7 +105,7 @@ If the model has been previously published, one should provide the reference to 
 
 ```
 
-!alert note
+
 The bibtex entries must be added into the VTB bibliography file +vtb.bib+. 
 A reference list will be generated automatically at the end of the VTB documentation page.
 
@@ -117,7 +117,7 @@ Description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 ### Other key model details to provide in the high-level summary style=font-size:125%
 
-- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please [click here](https://mooseframework.inl.gov/virtual_test_bed/resources/codes_used.html) to see the checklist, this can be used for the VTB team to categorize/sort the model)
+- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. 
 
 - Type of simulation: e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state
 
@@ -127,6 +127,9 @@ Description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 - Reactor Category(s): e.g., Liquid Metal Cooled Fast Reactor
 
+!alert note
+More information is available online about [the list of NEAMS codes](https://neams.inl.gov/code-descriptions/) and the codes that have been used for [the models available in VTB repository](https://mooseframework.inl.gov/virtual_test_bed/resources/codes_used.html). 
+Providing the related information in documentation can better help the VTB team to categorize/sort the model.
 
 ## Computational Model Description
 

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -7,26 +7,22 @@ Contact: Model Developer, model_developer.at.institute.com (contact email)
 High level introduction is expected here about the model of interest. Figures and tables can be added 
 in the model description, of which the examples are provided below. 
 
-### Adding a figure style=font-size:125%
 
-The markdown source is shown below, and one should put a copy of the figure at the specific file path.
-
-```language=bash
+!devel! example id=example-figure caption=Example of adding a figure in VTB documentation.
 !media msr/msre/SAM_MSRE_1D.png
-       style=width:60%
+       style=width:40%
        id=msre_sam
        caption=The steady-state temperature distribution in the 1-D MSRE primary loop.
+!devel-end!
 
-```
+!alert note
+One should put a copy of the figure at the specific file path.
+The VTB media is now arranged by reactor types under the folder +/media+. 
+For more detailed instructions on figure formatting, please refer to
+the [MooseDocs media tutorial](https://mooseframework.inl.gov/python/MooseDocs/extensions/media.html). 
 
-[Click here](msr/msre/msre_sam_model.md#msre_sam) to check out the formatted figure appeared on VTB website.
 
-
-### Adding a table style=font-size:125%
-
-The markdown source is shown below:
-
-```language=bash
+!devel! example id=example-table caption=Example of adding a table in VTB documentation.
 !table id=fuel_salt_properties caption=Thermophysical properties of the fuel salt.
 |   |   | Unit  | LiF-BeF$_4$-ZrF$_4$-UF$_4$  |
 | :- | :- | :- | :- |
@@ -35,16 +31,40 @@ The markdown source is shown below:
 | Dynamic viscosity | $\mu$ | $Pa\bullet s$ | $8.4\times 10^{-5} exp(4340/T)$ |
 | Thermal conductivity | $k$ | $W/(m\bullet K)$ | $1.0$ |
 | Specific heat capacity | $c_p$ | $J/(kg\bullet K)$ | $2009.66$ |
+!devel-end!
 
-```
+!alert note
+For more detailed instructions on table formatting, please refer to
+the [MooseDocs table tutorial](https://mooseframework.inl.gov/python/MooseDocs/extensions/table.html). 
 
-[Click here](msr/msre/msre_sam_model.md#fuel_salt_properties) to check out an example of a formatted table appearing on the VTB website.
+!devel! example id=example-equations caption=Example of adding equations in VTB documentation.
+NekRS solves the incompressible Navier-Stokes equations:
+
+\begin{equation}
+\label{eq:mass}
+\nabla\cdot\mathbf u=0
+\end{equation}
+
+\begin{equation}
+\label{eq:momentum}
+\rho_f\left(\frac{\partial\mathbf u}{\partial t}+\mathbf u\cdot\nabla\mathbf u\right)=-\nabla P+\nabla\cdot\tau+\rho\ \mathbf f
+\end{equation}
+
+\begin{equation}
+\label{eq:energy}
+\rho_f C_{p,f}\left(\frac{\partial T_f}{\partial t}+\mathbf u\cdot\nabla T_f\right)=\nabla\cdot\left(k_f\nabla T_f\right)+\dot{q}_f
+\end{equation}
+!devel-end!
+
+!alert note
+For more detailed instructions on equation formatting, please refer to
+the [MooseDocs equation tutorial](https://mooseframework.inl.gov/python/MooseDocs/extensions/katex.html).
+
 
 ### Adding references style=font-size:125%
 
 If the model has been previously published, one should provide the reference to the published works together with key references used for model development. 
-+MooseDocs+ supports BibTex style references, and some examples about how to cite technical report, conference proceeding and journal article are given below. The bibtex entries must be added into the VTB bibliography file +vtb.bib+. 
-A reference list will be generated automatically at the end of the VTB documentation page. 
++MooseDocs+ supports BibTex style references, and some examples about how to cite technical report, conference proceeding and journal article are given below.  
 
 ```language=bash
 @techreport{Hu2017,
@@ -85,16 +105,14 @@ A reference list will be generated automatically at the end of the VTB documenta
 
 ```
 
-To cite the references, one can do the following in the markdown file.
+!alert note
+The bibtex entries must be added into the VTB bibliography file +vtb.bib+. 
+A reference list will be generated automatically at the end of the VTB documentation page.
 
-```language=bash
-description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
 
-```
-
-This will appear on the page as:
-
-description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
+!devel! example id=example-refs caption=Example of inserting citations in VTB documentation.
+Description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
+!devel-end!
 
 
 ### Other key model details to provide in the high-level summary style=font-size:125%
@@ -113,17 +131,11 @@ description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 ## Computational Model Description
 
 Walk through the main kernel/blocks, show snippets of example inputs when needed. 
-
 The markdown source can be as simple as the following to show the `EOS` block from the `msre_loop.i` input file:
 
-```language=bash
+!devel! example id=example-list caption=Example of including input block in VTB documentation.
 !listing msr/msre/msre_loop_1d.i block=EOS language=cpp
-
-```
-
-It would bring up the corresponding block in the specific input file.
-
-!listing msr/msre/msre_loop_1d.i block=EOS language=cpp
+!devel-end!
 
 
 ## Results

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -7,7 +7,7 @@ Contact: Model Developer, model_developer.at.institute.com (contact email)
 High level introduction is expected here about the model of interest. Figures and tables can be added 
 in the model description, of which the examples are provided below. 
 
-#### Adding a figure
+### Adding a figure style=font-size:125%
 
 The markdown source is shown below, and one should put a copy of the figure at the specific file path.
 
@@ -19,10 +19,10 @@ The markdown source is shown below, and one should put a copy of the figure at t
 
 ```
 
-[Click here](msr/msre/msre_sam_model.md#msre_sam) to check out the formatted figure appeared on VTB website:
+[Click here](msr/msre/msre_sam_model.md#msre_sam) to check out the formatted figure appeared on VTB website.
 
 
-#### Adding a table
+### Adding a table style=font-size:125%
 
 The markdown source is shown below:
 
@@ -38,13 +38,13 @@ The markdown source is shown below:
 
 ```
 
-[Click here](msr/msre/msre_sam_model.md#fuel_salt_properties) to check out the formatted table appeared on VTB website:
+[Click here](msr/msre/msre_sam_model.md#fuel_salt_properties) to check out an example of a formatted table appearing on the VTB website.
 
-#### Adding references
+### Adding references style=font-size:125%
 
-If the model has been previously published, one should provide the reference to the published works together with the key references used for model development. 
-The Latex style references are supported in MOOSE documentation, and some examples about how to cite technical report, conference proceedings and journal articles are given below. The bibtex entries have to be added into file `vtb.bib`. 
-A bibliography list will be generated automatically at the end of the document. 
+If the model has been previously published, one should provide the reference to the published works together with key references used for model development. 
++MooseDocs+ supports BibTex style references, and some examples about how to cite technical report, conference proceeding and journal article are given below. The bibtex entries must be added into the VTB bibliography file +vtb.bib+. 
+A reference list will be generated automatically at the end of the VTB documentation page. 
 
 ```language=bash
 @techreport{Hu2017,
@@ -92,16 +92,20 @@ description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 ```
 
+This will appear on the page as:
+
 description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
 
 
-#### Other key model details to provide in the high-level summary
+### Other key model details to provide in the high-level summary style=font-size:125%
 
-- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please click here to see the checklist, this can be used for Guillaume to categorize/sort)
+- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please click here to see the checklist, this can be used for the VTB team to categorize/sort the model)
 
-- Type of simulation (e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state)
+- Type of simulation: e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state
 
-- External Code (non-MOOSE based) used: MC2-3, Cubit, etc.
+- Non-MOOSE Based NEAMS Code Used: MC2-3, Nek5000/RS, etc. 
+
+- External Code (non-NEAMS based) Used: Cubit, OpenFOAM, etc.
 
 - Reactor Category(s): e.g., Liquid Metal Cooled Fast Reactor
 
@@ -110,7 +114,7 @@ description part A [!citep](Hu2017), description part B [!citep](novak_2021c), d
 
 Walk through the main kernel/blocks, show snippets of example inputs when needed. 
 
-The markdown source can be as simple as the following:
+The markdown source can be as simple as the following to show the `EOS` block from the `msre_loop.i` input file:
 
 ```language=bash
 !listing msr/msre/msre_loop_1d.i block=EOS language=cpp
@@ -132,7 +136,7 @@ Here one can document the most important results from the related simulations. P
 Please provide the run command for model execution on INL’s HPC Cluster or otherwise. Below is a simple example how to run a SAM system modeling job. 
 
 ```language=bash
-sam-opt -i pbfhr-ss.i
+mpirun -np 48 /path/to/sam-opt -i sam_input.i
 
 ```
 

--- a/doc/content/template.md
+++ b/doc/content/template.md
@@ -1,0 +1,139 @@
+# Model Name
+
+Contact: Model Developer, model_developer.at.institute.com (contact email) 
+
+## High Level Summary of Model
+
+High level introduction is expected here about the model of interest. Figures and tables can be added 
+in the model description, of which the examples are provided below. 
+
+#### Adding a figure
+
+The markdown source is shown below, and one should put a copy of the figure at the specific file path.
+
+```language=bash
+!media msr/msre/SAM_MSRE_1D.png
+       style=width:60%
+       id=msre_sam
+       caption=The steady-state temperature distribution in the 1-D MSRE primary loop.
+
+```
+
+[Click here](msr/msre/msre_sam_model.md#msre_sam) to check out the formatted figure appeared on VTB website:
+
+
+#### Adding a table
+
+The markdown source is shown below:
+
+```language=bash
+!table id=fuel_salt_properties caption=Thermophysical properties of the fuel salt.
+|   |   | Unit  | LiF-BeF$_4$-ZrF$_4$-UF$_4$  |
+| :- | :- | :- | :- |
+| Melting temperature | $T_{melt}$ | $K$ | $722.15$  |
+| Density | $\rho$ | $kg/m^3$  | $2553.3-0.562\bullet T$ |
+| Dynamic viscosity | $\mu$ | $Pa\bullet s$ | $8.4\times 10^{-5} exp(4340/T)$ |
+| Thermal conductivity | $k$ | $W/(m\bullet K)$ | $1.0$ |
+| Specific heat capacity | $c_p$ | $J/(kg\bullet K)$ | $2009.66$ |
+
+```
+
+[Click here](msr/msre/msre_sam_model.md#fuel_salt_properties) to check out the formatted table appeared on VTB website:
+
+#### Adding references
+
+If the model has been previously published, one should provide the reference to the published works together with the key references used for model development. 
+The Latex style references are supported in MOOSE documentation, and some examples about how to cite technical report, conference proceedings and journal articles are given below. The bibtex entries have to be added into file `vtb.bib`. 
+A bibliography list will be generated automatically at the end of the document. 
+
+```language=bash
+@techreport{Hu2017,
+        address = {Lemont, IL},
+        author = {Hu, Rui},
+        number = {ANL/NE-17/4},
+        mendeley-tags = {ANL/NE-17/4},
+        institution = {Argonne National Laboratory},
+        title = {{SAM Theory Manual}},
+        year = {2017}
+}
+
+```
+
+```language=bash
+@InProceedings{novak_2021c,
+  title       = {{Coupled {Monte} {Carlo} and Thermal-Hydraulics Modeling of a Prismatic Gas Reactor Fuel Assembly Using {Cardinal}}},
+  author     = {A.J. Novak and D. Andrs and P. Shriwise and D. Shaver and P.K. Romano and E. Merzari and P. Keutelian},
+  booktitle  = {{Proceedings of Physor}},
+  year       = 2021
+}
+
+```
+
+```language=bash
+@article{Fang2021,
+        author = {Fang, Jun and Shaver, Dillon R. and Min, Misun and Fischer, Paul
+                and Lan, Yu-Hsiang and Rahaman, Ronald and Romano, Paul
+                and Benhamadouche, Sofiane and Hassan, Yassin A.
+                and Kraus, Adam and Merzari, Elia},
+        doi = {10.1016/j.nucengdes.2021.111143},
+        journal = {Nuclear Engineering and Design},
+        title = {{Feasibility of Full-Core Pin Resolved CFD Simulations of
+                Small Modular Reactor with Momentum Sources}},
+        volume = {378},
+        year = {2021}
+}
+
+```
+
+To cite the references, one can do the following in the markdown file.
+
+```language=bash
+description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
+
+```
+
+description part A [!citep](Hu2017), description part B [!citep](novak_2021c), description part C [!citep](Fang2021)
+
+
+#### Other key model details to provide in the high-level summary
+
+- MOOSE Based Applications Used: Griffin, Heat Conduction, Cardinal, etc. (Please click here to see the checklist, this can be used for Guillaume to categorize/sort)
+
+- Type of simulation (e.g., 3D core multiphysics (neutronics-TH) transient, 1D system steady-state)
+
+- External Code (non-MOOSE based) used: MC2-3, Cubit, etc.
+
+- Reactor Category(s): e.g., Liquid Metal Cooled Fast Reactor
+
+
+## Computational Model Description
+
+Walk through the main kernel/blocks, show snippets of example inputs when needed. 
+
+The markdown source can be as simple as the following:
+
+```language=bash
+!listing msr/msre/msre_loop_1d.i block=EOS language=cpp
+
+```
+
+It would bring up the corresponding block in the specific input file.
+
+!listing msr/msre/msre_loop_1d.i block=EOS language=cpp
+
+
+## Results
+
+Here one can document the most important results from the related simulations. Please refer to aforementioned examples about how to add figures and tables when discussing the main results and discoveries. 
+
+
+## Run Command 
+
+Please provide the run command for model execution on INL’s HPC Cluster or otherwise. Below is a simple example how to run a SAM system modeling job. 
+
+```language=bash
+sam-opt -i pbfhr-ss.i
+
+```
+
+


### PR DESCRIPTION
This PR contains a documentation template for potential VTB model contributors. It lists the main components expected in a standard VTB documentation. Some examples about how to insert figure, table, and references are provided. This is just an initial version based on the suggestions of Emily and Abdalla. We will keep maintaining the template by adding more useful details to best support new contributors. 