### PR TITLE
Fix blue crab test failures

### DIFF
--- a/htgr/mhtgr/mhtgr_sam/tests
+++ b/htgr/mhtgr/mhtgr_sam/tests
@@ -5,5 +5,7 @@
     check_input = True
     executable_pattern = 'sam*|blue_crab*'
     cli_args = '--app SamApp'
+
+    allow_unused = true
   []
 []

--- a/msr/msfr/plant/steady/run_ns.i
+++ b/msr/msfr/plant/steady/run_ns.i
@@ -113,6 +113,7 @@ beta6 = 0.000184087
     add_energy_equation = true
     add_scalar_equation = true
     boussinesq_approximation = true
+    block = 'fuel pump hx'
 
     # Variables, defined below for the Exodus restart
     velocity_variable = 'vel_x vel_y'

--- a/msr/msfr/plant/transient/run_ns.i
+++ b/msr/msfr/plant/transient/run_ns.i
@@ -79,6 +79,7 @@ beta6 = 0.000184087
     add_energy_equation = true
     add_scalar_equation = true
     boussinesq_approximation = true
+    block = 'fuel pump hx'
 
     # Variables, defined below for the Exodus restart
     velocity_variable = 'vel_x vel_y'

--- a/msr/msfr/steady/run_ns.i
+++ b/msr/msfr/steady/run_ns.i
@@ -114,6 +114,7 @@ beta6 = 0.000184087
     add_energy_equation = true
     add_scalar_equation = true
     boussinesq_approximation = true
+    block = 'fuel pump hx'
 
     # Variables, defined below for the Exodus restart
     velocity_variable = 'vel_x vel_y'

--- a/msr/msfr/transient/run_ns.i
+++ b/msr/msfr/transient/run_ns.i
@@ -79,6 +79,7 @@ beta6 = 0.000184087
     add_energy_equation = true
     add_scalar_equation = true
     boussinesq_approximation = true
+    block = 'fuel pump hx'
 
     # Variables, defined below for the Exodus restart
     velocity_variable = 'vel_x vel_y'

--- a/msr/msre/steady_state/msre_loop_1d.i
+++ b/msr/msre/steady_state/msre_loop_1d.i
@@ -48,7 +48,6 @@
     rho      = fuel_salt_rho_func
     mu       = fuel_salt_mu_func
     enthalpy = fuel_salt_enthalpy_func
-    beta     = 3.1247E-04
     cp       = 2009.66
     k        = 1.0
   [../]
@@ -313,10 +312,8 @@
     Ts_init            = 824.8167
 
     HS_BC_type                    = 'Coupled Coupled'
-    eos_left                      = hx_salt_eos
     name_comp_left                = hx_tube1
     HT_surface_area_density_left  = 8.6290E+02
-    eos_right                     = fuel_salt_eos
     name_comp_right               = hx_shell
     HT_surface_area_density_right = 2.3629E+02
   [../]
@@ -336,10 +333,8 @@
     Ts_init            = 824.8167
 
     HS_BC_type                    = 'Coupled Coupled'
-    eos_left                      = hx_salt_eos
     name_comp_left                = hx_tube3
     HT_surface_area_density_left  = 8.6290E+02
-    eos_right                     = fuel_salt_eos
     name_comp_right               = hx_shell
     HT_surface_area_density_right = 2.3629E+02
   [../]


### PR DESCRIPTION
New block check in MOOSE for NSFV action is too restrictive
Unused parameters are now making the tests error because of a restored default