### PR TITLE
Cardinal updates

### DIFF
--- a/doc/content/htgr/pb67_cardinal/CardinalandMOOSE.md
+++ b/doc/content/htgr/pb67_cardinal/CardinalandMOOSE.md
@@ -36,6 +36,8 @@ stores its solution fields and mesh. But once the wrapping is constructed, nekRS
 then communicate with any other MOOSE application via the [MultiApp]((https://mooseframework.inl.gov/syntax/MultiApps/index.html)
 and [Transfer](https://mooseframework.inl.gov/syntax/Transfers/index.html) systems
 in MOOSE, enabling complex multiscale thermal-hydraulic analysis and multiphysics feedback.
+Note that the user does not need to construct this mapping themselves - it all happens
+automatically.
 The same wrapping can be used for conjugate heat transfer analysis with *any* MOOSE
 application that can compute a heat flux; that is, because a MOOSE-wrapped version of nekRS
 interacts with the MOOSE framework in a similar manner as natively-developed

--- a/doc/content/htgr/pb67_cardinal/index.md
+++ b/doc/content/htgr/pb67_cardinal/index.md
@@ -3,8 +3,8 @@
 *Contact: John Acierno (Penn State), Dillon Shaver (dshaver.at.anl.gov), and April Novak (anovak.at.anl.gov)* 
 
 In this tutorial we are going to set up and simulate a simple [!ac](CHT) case using a helium (Pr=0.71) cooled 67-pebble bed.
-This tutorial was developed from an example case provided with NekRS and couples to MOOSE's [!ac](CHT) module using CARDINAL as a wrapper. 
-More information about the NEAMS tool CARDINAL can be found on [github](https://github.com/neams-th-coe/cardinal), or on the [Cardinal website](https://cardinal.cels.anl.gov/).
+This tutorial was developed from an example case provided with NekRS and couples to MOOSE's [!ac](CHT) module using Cardinal as a wrapper. 
+More information about the NEAMS tool Cardinal can be found on [github](https://github.com/neams-th-coe/cardinal), or on the [Cardinal website](https://cardinal.cels.anl.gov/).
 In each time step MOOSE will solve the energy equation in the the solid subdomain and pass the solution to NekRS, which will in-turn solve both the Navier-Stokes and energy equations in the fluid subdomain.
 NekRS will then pass its temperature solution back to MOOSE in the next time step. 
 This transfer of information occurs at the boundary between solid and fluid subdomains, which are the pebble surfaces in this case.
@@ -70,7 +70,10 @@ The +.par+ file lists the necessary input parameters to nekRS simulations.
 
 !listing /htgr/pb67_cardinal/pb67.par language=ini
 
-The +CUDA+ backend is enabled in ```[OCCA]``` block to allow nekRS running on GPU hardware. The specific filtering settings allow us to smooth out high frequencies. If you are planning on doing a DNS you should not include any filtering.
+If you want to run this example on GPUs, you simply need to pass `--nekrs-backend CUDA --nekrs-device-id 0`
+on the command line later when we run the `cardinal-opt` executable. Otherwise, this example
+will be run on a CPU backend.
+The specific filtering settings allow us to smooth out high frequencies. If you are planning on doing a DNS you should not include any filtering.
 Next, the parameters in ```[PRESSURE]``` block are selected to have a short time-to-solution. We are able to achieve this by adding a preconditioner and a smoother. In NekRS version 21.1 the combination of semg preconditioner with ```chebyshev+asm``` smoothers works well, but in later versions 22.0+, using the amgx preconditioner with ```chebyshev+jac``` smoothers is much faster.
 
 ### usr file style=font-size:125%
@@ -85,7 +88,7 @@ This results in flow moving around the chamfered area without an additional heat
 
 ## MOOSE setup
 
-As previously stated, we strongly recommend completing the CHT tutorials on CARDINAL, which fully describe every aspect of the MOOSE setup. Here, we will only cover case specific necessities.
+As previously stated, we strongly recommend completing the CHT tutorials on Cardinal, which fully describe every aspect of the MOOSE setup. Here, we will only cover case specific necessities.
 
 In this case we need to create two files: +nek.i+ and +moose.i+ pertaining to the NekRS and MOOSE parameters respectively.
 
@@ -93,24 +96,33 @@ Starting with the simpler +nek.i+ which contains the following
 
 !listing /htgr/pb67_cardinal/nek.i
 
-In the ```[MESH]``` block, MOOSE will create a copy of the Nek mesh at the given boundaries. In this case it is at the pebble surfaces. 
+In the ```[Mesh]``` block, MOOSE will create a copy of the Nek mesh at the given boundaries. In this case it is at the pebble surfaces. 
 In the ```[Problem]``` block we define the name of corresponding NekRS files. 
 Next, we want MOOSE to use the same time steps as Nek so we prescribe that in the ```[Executioner]``` block. 
 In the ```[Output]``` block we tell MOOSE to output an exodus file of the shallow Nek copy every 1,000 time steps. This can be a helpful check at the beginning of the simulation to make sure you are using the correct boundaries. 
 Finally, in the ```[Postprocessor]``` block we define what values we want MOOSE to calculate for us. Here we want the integral flux, min, max, and average temperature at the pebble surface.
+
+!alert note
+Note that in this file, we are copying the *non-dimensional* nekRS solution into Cardinal.
+In this case, the coupled MOOSE heat conduction will also be represented in non-dimensional
+form. If we wanted to instead transform the non-dimensional nekRS solution into an equivalent
+dimensional form (which would allow us to represent the solid heat conduction with dimensional units),
+we'd simply set `nondimensional = true` for `NekRSProblem` and then set the characteristic
+scales, `U_ref`, `T_ref`, `dT_ref`, `L_ref`, `rho_0`, and `Cp_0`. For more information, see
+the [NekRSProblem](https://cardinal.cels.anl.gov/source/problems/NekRSProblem.html) documentation.
 
 To setup the MOOSE mesh, a text file containing the center points of each pebble is necessary. 
 For the bed used in this case, the file can be obtained [here](/htgr/pb67_cardinal/positions.txt).
 
 !listing /htgr/pb67_cardinal/moose.i
 
-Notice in the ```[MESH]``` block we are using a file to generate the solid mesh. Make sure to include the sphere.e file in your working directory. We use this single sphere of radius 1 and duplicate it using `CombinerGenerator` and all of the coordinates of the 67 pebbles given in +positions.txt+. 
-From here we scale down the pebbles to ensure that they are not touching in the solid mesh. We then call the heat conduction module in the ```[KERNEL]``` block ensuring MOOSE will solve the temperature in the solid mesh. 
-Then we tell MOOSE to match the boundary conidtions use in Nek in the ```[BCs]``` block. In the ```[TRANSFER]``` block we define what and how variables get transfered. We define a multi app and transfer the temperature from Nek to MOOSE and return the average flux and flux integral back to Nek. Built in post-processors are used to obtain these values. Finally, we define an aux kernel to model the avg flux. Notice in +nek.i+ the boundary from nek is 4 and in +moose.i+ the boundary of interest is 1. Be sure not to mix up the boundaries in the fluid and solid mesh.
+Notice in the ```[Mesh]``` block we are using a file to generate the solid mesh. Make sure to include the sphere.e file in your working directory. We use this single sphere of radius 1 and duplicate it using `CombinerGenerator` and all of the coordinates of the 67 pebbles given in +positions.txt+. 
+From here we scale down the pebbles to ensure that they are not touching in the solid mesh. We then call the heat conduction module in the ```[Kernels]``` block ensuring MOOSE will solve the temperature in the solid mesh. 
+Then we tell MOOSE to match the boundary conditions use in Nek in the ```[BCs]``` block. In the ```[Transfers]``` block we define what and how variables get transfered. We define a multi app and transfer the temperature from Nek to MOOSE and return the average flux and flux integral back to Nek. Built in post-processors are used to obtain these values. Finally, we define an aux kernel to model the avg flux. Notice in +nek.i+ the boundary from nek is 4 and in +moose.i+ the boundary of interest is 1. Be sure not to mix up the boundaries in the fluid and solid mesh.
 
 ## Results
 
-Below are 3D renderings done in VisIt of the velocity(left) and temperature(right) fields.
+Below are 3D renderings done in VisIt of the velocity (left) and temperature (right) fields.
 
 !media pb67_cardinal/pb67_3D_renderings.png
   style=width:70%;margin-left:auto;margin-right:auto

--- a/doc/content/resources/codes_used.md
+++ b/doc/content/resources/codes_used.md
@@ -11,6 +11,7 @@ The codes required to run these inputs are all open-source. Please refer to the 
 - Molten Salt Fast Reactor core CFD [documentation](msr/msfr/nek5000_cfd_model.md) and [inputs](https://github.com/idaholab/virtual_test_bed/tree/main/msr/msfr/core_cfd)\\
 - HTGR assembly multiphysics simulation [documentation](htgr/assembly/index.md) and [inputs](https://github.com/idaholab/virtual_test_bed/tree/htgr/assembly)\\
 - Sodium Fast Reactor duct bowing [documentation](sfr/hex_duct_bowing/index.md) and [inputs](https://github.com/idaholab/virtual_test_bed/tree/main/sfr/hex_duct_bowing)
+- HTGR pebble bed Large Eddy Simulation with conjugate heat transfer [documentation](htgr/pb67_cardinal/index.md) and [inputs](https://github.com/idaholab/virtual_test_bed/tree/devel/htgr/pb67_cardinal)
 
 
 !alert note title=Partially Open-Source

--- a/htgr/pb67_cardinal/moose.i
+++ b/htgr/pb67_cardinal/moose.i
@@ -82,26 +82,22 @@
   [nek_temp]
     type = MultiAppNearestNodeTransfer
     source_variable = temp
-    direction = from_multiapp
-    multi_app = nek
+    from_multi_app = nek
     variable = nek_temp
     fixed_meshes = true
   []
   [avg_flux]
     type = MultiAppNearestNodeTransfer
     source_variable = avg_flux
-    direction = to_multiapp
-    multi_app = nek
+    to_multi_app = nek
     variable = avg_flux
     fixed_meshes = true
   []
   [flux_integral_to_nek]
     type = MultiAppPostprocessorTransfer
     to_postprocessor = flux_integral
-    direction = to_multiapp
     from_postprocessor = flux_integral
-    multi_app = nek
-    fixed_meshes = true
+    to_multi_app = nek
   []
 []
 

--- a/htgr/pb67_cardinal/pb67.par
+++ b/htgr/pb67_cardinal/pb67.par
@@ -1,11 +1,10 @@
 [GENERAL]
-#verbose = true
 polynomialOrder = 7
 #startFrom = "restart.fld"
 stopAt = endTime
-endTime = 20
+endTime = 500
 
-dt = 2.0e-3
+dt = 1.0e-05
 timeStepper = tombo2
 subCyclingSteps = 2
 
@@ -19,18 +18,18 @@ filterModes = 2
 [PRESSURE]
 residualTol = 1e-04
 residualProj = yes
-coarseGridDiscretization = SEMFEM
-smootherType = chebyshev+asm
-residualProjectionVectors = 30
+preconditioner = multigrid
+smootherType = chebyshev+jac
+initialGuess = projectionAconj + nVector = 30
 
 [VELOCITY]
 boundaryTypeMap = inlet, outlet, wall, wall
 density = 1.0
-viscosity = -5000.0
+viscosity = -1460.0
 residualTol = 1e-06
 
 [TEMPERATURE]
 boundaryTypeMap = t,I,I,f
 residualTol = 1e-06
 rhoCp = 1.0
-conductivity = -3550.0
+conductivity = -1036.0

--- a/htgr/pb67_cardinal/pb67.par
+++ b/htgr/pb67_cardinal/pb67.par
@@ -1,7 +1,3 @@
-[OCCA]
-backend = CUDA
-deviceNumber = 0
-
 [GENERAL]
 #verbose = true
 polynomialOrder = 7
@@ -13,8 +9,8 @@ dt = 2.0e-3
 timeStepper = tombo2
 subCyclingSteps = 2
 
-writeControl = runTime
-writeInterval = 1
+writeControl = steps
+writeInterval = 500
 
 filtering = hpfrt
 filterWeight = 0.2/${dt}
@@ -23,7 +19,7 @@ filterModes = 2
 [PRESSURE]
 residualTol = 1e-04
 residualProj = yes
-preconditioner = semg
+#preconditioner = semg
 smootherType = chebyshev+asm
 residualProjectionVectors = 30
 

--- a/htgr/pb67_cardinal/pb67.par
+++ b/htgr/pb67_cardinal/pb67.par
@@ -19,7 +19,7 @@ filterModes = 2
 [PRESSURE]
 residualTol = 1e-04
 residualProj = yes
-#preconditioner = semg
+coarseGridDiscretization = SEMFEM
 smootherType = chebyshev+asm
 residualProjectionVectors = 30
 

--- a/htgr/pb67_cardinal/pb67.udf
+++ b/htgr/pb67_cardinal/pb67.udf
@@ -25,11 +25,11 @@ void uservp(nrs_t *nrs, dfloat time, occa::memory o_U, occa::memory o_S,
 
 /* UDF Functions */
 
-void UDF_LoadKernels(nrs_t *nrs)
+void UDF_LoadKernels(occa::properties & kernelInfo)
 {
  // avg::buildKernel(nrs);
-  cliptKernel = udfBuildKernel(nrs, "cliptOKL");
-  userVpKernel = udfBuildKernel(nrs, "userVp");
+  cliptKernel = oudfBuildKernel(kernelInfo, "cliptOKL");
+  userVpKernel = oudfBuildKernel(kernelInfo, "userVp");
 }
 
 void UDF_Setup(nrs_t *nrs)

--- a/htgr/pb67_cardinal/pb67.usr
+++ b/htgr/pb67_cardinal/pb67.usr
@@ -70,7 +70,7 @@ c-----------------------------------------------------------------------
         if(cbc(ifc,iel,1) .eq. 'W ') boundaryID(ifc,iel)=3
         if(cbc(ifc,iel,1) .eq. 'WH ') boundaryID(ifc,iel)=4
       enddo
-      end`do
+      enddo
 
       do iel=1,nelt
       do ifc=1,2*ndim

--- a/pbfhr/reflector/cht/fluid.par
+++ b/pbfhr/reflector/cht/fluid.par
@@ -19,7 +19,7 @@
   numSteps = 2000
   dt = 0.001
   timeStepper = tombo2
-  writeControl = numSteps
+  writeControl = steps
   writeInterval = 100
   polynomialOrder = 4
 
@@ -33,7 +33,6 @@
 [PRESSURE]
   residualTol = 1.0e-8
   residualProj = false
-  preconditioner = semg_amg
 
 [TEMPERATURE]
   conductivity = -1500.5

--- a/pbfhr/reflector/cht/fluid.udf
+++ b/pbfhr/reflector/cht/fluid.udf
@@ -1,10 +1,7 @@
 #include "udf.hpp"
 
-void UDF_LoadKernels(nrs_t *nrs)
+void UDF_LoadKernels(occa::properties & kernelInfo)
 {
-  setupAide & options = platform->options;
-  occa::properties & kernelInfo = *nrs->kernelInfo;
-
   // Compute the inlet velocity boundary condition and propagate it to a kernel variable
   kernelInfo["defines/Vz"] = 1.0;
 

--- a/pbfhr/reflector/conduction/fluid.par
+++ b/pbfhr/reflector/conduction/fluid.par
@@ -18,7 +18,7 @@
   numSteps = 2000
   dt = 0.025
   timeStepper = tombo2
-  writeControl = numSteps
+  writeControl = steps
   writeInterval = 100
   polynomialOrder = 2
 
@@ -33,7 +33,6 @@
 [PRESSURE]
   residualTol = 1.0e-8
   residualProj = false
-  preconditioner = semg_amg
 
 [TEMPERATURE]
   conductivity = -1500.5

--- a/pbfhr/reflector/conduction/fluid.udf
+++ b/pbfhr/reflector/conduction/fluid.udf
@@ -1,5 +1,9 @@
 #include "udf.hpp"
 
+void UDF_LoadKernels(occa::properties& kernelInfo)
+{
+}
+
 void UDF_Setup(nrs_t *nrs)
 {
   mesh_t * mesh = nrs->cds->mesh[0];


### PR DESCRIPTION
This PR updates syntax in the Cardinal cases to be compatible with the newer NekRS version (which we have updated in Cardinal). I also made some minor changes to the 67 pebble bed Cardinal case, to use `Cardinal` in place of `CARDINAL` (for consistency elsewhere) and added a bit more context/info where I thought it could help improve clarity.

@hapfang I am not sure what is the new syntax for the `preconditioner = semg_amg`. It doesn't exist any more in v22 - do you happen to know what I should change that to?

Closes #182