### PR TITLE
Remove a parameter in the input

### DIFF
--- a/microreactors/s8er/core_2D_griffin_coupled.i
+++ b/microreactors/s8er/core_2D_griffin_coupled.i
@@ -400,19 +400,17 @@ inlet_T_fluid             = 949.81667 # (K)
 []
 
 [UserObjects]
-    # [core_vol_adjust] # TO BE FIXED
+    # [core_vol_adjust] # TO BE FIXED (number of 'vol' needs to match the number of blocks)
     #     type = VolumeAdjuster
     #     block = '1 2 3 4 5 6 7 8 9 10'
     #     vol = 0.040999863
     #     execute_on = 'initial timestep_begin timestep_end'
-    #     correct_XS = true
     # []
     [int_ref_vol_adjust]
         type = VolumeAdjuster
         block = '11'
         vol = 0.00331416
         execute_on = 'initial timestep_begin timestep_end'
-        correct_XS = true
     []
     # [Tcore]
     #     type = LayeredAverage


### PR DESCRIPTION
Because its value is the same as the default value. The parameter will be removed soon. Close #198. @GiudGiud 