### PR TITLE
Remove fission_source_integral postprocessor when there is CMFD

### DIFF
--- a/microreactors/gcmr/assembly/steady_state/Griffin_steady_state.i
+++ b/microreactors/gcmr/assembly/steady_state/Griffin_steady_state.i
@@ -44,7 +44,7 @@
   max_inner_its = 20
 
   fixed_point_max_its = 1
-  custom_pp = fission_source_integral
+  custom_pp = eigenvalue
   custom_rel_tol = 1e-6
   force_fixed_point_solve = true
 

--- a/microreactors/gcmr/assembly/transient/Griffin_transient.i
+++ b/microreactors/gcmr/assembly/transient/Griffin_transient.i
@@ -38,7 +38,6 @@
   richardson_abs_tol = 5e-6
   richardson_rel_tol = 1e-8
   richardson_max_its = 1000
-  richardson_value = fission_source_integral
 
   inner_solve_type = GMRes
   max_inner_its = 20


### PR DESCRIPTION
`fission_source_integral` postprocessor loses its meaning when there is CMFD acceleration and will be no longer added by Griffin (https://github.inl.gov/ncrc/griffin/pull/1147).