### PR TITLE
Deprecate residualProj.

### DIFF
--- a/htgr/httf/lower_plenum_mixing/httf.par
+++ b/htgr/httf/lower_plenum_mixing/httf.par
@@ -27,7 +27,6 @@ residualPROJ = yes
 [PRESSURE]
 preconditioner = semg_amg_hypre
 residualTol = 1e-04
-residualProj = yes
 
 [TEMPERATURE]
 #solver = none

--- a/htgr/pb67_cardinal/pb67.par
+++ b/htgr/pb67_cardinal/pb67.par
@@ -17,7 +17,6 @@ filterModes = 2
 
 [PRESSURE]
 residualTol = 1e-04
-residualProj = yes
 preconditioner = multigrid
 smootherType = chebyshev+jac
 initialGuess = projectionAconj + nVector = 30

--- a/pbfhr/reflector/cht/fluid.par
+++ b/pbfhr/reflector/cht/fluid.par
@@ -27,12 +27,10 @@
   viscosity = -100.0
   density = 1.0
   residualTol = 1.0e-8
-  residualProj = false
   boundaryTypeMap = W, W, symy, W, v, o, W, W
 
 [PRESSURE]
   residualTol = 1.0e-8
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = -1500.5

--- a/pbfhr/reflector/conduction/fluid.par
+++ b/pbfhr/reflector/conduction/fluid.par
@@ -27,12 +27,10 @@
   viscosity = -100.0
   density = 1.0
   residualTol = 1.0e-8
-  residualProj = false
   boundaryTypeMap = W, W, symy, W, v, o, W, W
 
 [PRESSURE]
   residualTol = 1.0e-8
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = -1500.5


### PR DESCRIPTION
This deprecates a parameter which will be removed from the next NekRS release (I believe it currently actually does nothing, but was just lingering around in these files).