### PR TITLE
Update to the HTTF lower plenum CFD modeling by adding nekRS model and documentation

### DIFF
--- a/doc/content/bib/vtb.bib
+++ b/doc/content/bib/vtb.bib
@@ -1,4 +1,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% references for the nekRS HTTF lower plenum model
+@article{Podila2022,
+author = {Podila, K and Chen, Q and Huang, X and Li, C and Rao, Y and Waddington, G and Jafri, T},
+doi = {10.1016/j.nucengdes.2022.111858},
+issn = {0029-5493},
+journal = {Nuclear Engineering and Design},
+pages = {111858},
+title = {{Coupled simulations for prismatic gas-cooled reactor}},
+url = {https://www.sciencedirect.com/science/article/pii/S0029549322002126},
+volume = {395},
+year = {2022}
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % references for the Nek5000 Air Jacket Model
 @article{jones_air_1978,
   title = {The {Air} {Density} {Equation} and the {Transfer} of the {Mass} {Unit}},

--- a/doc/content/htgr/httf/index.md
+++ b/doc/content/htgr/httf/index.md
@@ -5,3 +5,5 @@
 [HTTF RELAP-7 model](htgr/httf/httf_multiapp_model.md)
 
 [HTTF model results](htgr/httf/httf_multiapp_results.md)
+
+[HTTF lower plenum CFD model](htgr/httf/lower_plenum_cfd.md)

--- a/doc/content/htgr/httf/lower_plenum_cfd.md
+++ b/doc/content/htgr/httf/lower_plenum_cfd.md
@@ -82,7 +82,7 @@ The mean LP pressure is 100.5 $kPa$, with which the helium gas has a density of 
 
 ### Nek5000 sase setups style=font-size:125%
 
-The reader can find the Nek5000 case files and the associated HTTF lower plenum files (through github LFS) in VTB repository. The mesh information is contained in two files: +httf.re2+ (grid coordinates, sideset ids, etc.) and +httf.co2+ (mesh cell connectivity).
+The reader can find the Nek5000 case files and the associated HTTF lower plenum mesh files (through github LFS) in VTB repository. The mesh information is contained in two files: +httf.re2+ (grid coordinates, sideset ids, etc.) and +httf.co2+ (mesh cell connectivity).
 As for the Nek5000 case files, there are +SIZE+, +httf.par+, +httf.usr+, and two auxiliary files +limits.f+ and +utilities.f+ that hosts various post-processing functions, such as solution monitoring, planar averaging, and so forth.
 +SIZE+ is the metafile to specify primary discretization parameters.
 +httf.usr+ is the script where users specify the boundary conditions, turbulence modeling approach and post-processing.
@@ -170,19 +170,17 @@ In the era of Exascale computing, there's a notable shift towards accelerated co
 ### Boundary conditions style=font-size:125%
 
 The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories. The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m3 with a reference temperature of 895.7 K. 
-Table 3 summarizes the key thermophysical properties of helium flow used in the NekRS simulations.  The 234 inlet channels are divided into 32 groups here as shown in [new_grouping] 
+[he_condition] summarizes the key thermophysical properties of helium flow used in the NekRS simulations.  The 234 inlet channels are divided into 32 groups here as shown in [new_grouping] 
 based on the radial locations and polar angles, and each group with specific mass flow rate and temperature. Inlet channels within a certain group are assumed to have the same inflow velocity corresponding to the specific mass flow rate. 
-Details of the inlet boundary conditions are listed in Table 4.
-Figure 11 visually illustrates the boundary conditions that are enumerated in Table 4. 
-All wall surfaces are assumed to have no-slip velocity boundary condition and adiabatic thermal boundary condition. And a natural pressure condition is given to the outlet face of hot duct. The CFD simulations were carried out in a dimensionless manner. The reference velocity is the mean flow velocity at hot duct, which is 41.48 m/s. Normalization of temperature is accomplished by referencing it to the maximum inlet temperature of 984.34 K at CG0 group and the minimum inlet temperature of 810.05 K at the outer bypass group. Subsequently, during the post-processing stage, it is straightforward to convert the computational fluid dynamics (CFD) outcomes back into dimensional values, enabling additional analyses to be conducted.
+Details of the inlet boundary conditions are listed in [inlet_bc].
+[new_bc] visually illustrates the boundary conditions that are enumerated in [inlet_bc]. 
 
 !media httf/lower_plenum_cfd/new_grouping.png
        style=width:60%
        id=new_grouping
        caption=The grouping of lower plenum inlet channels.
 
-
-!table id=new_bc caption=Helium thermo-physical properties and flow conditions.
+!table id=he_condition caption=Helium thermo-physical properties and flow conditions.
 | $-$ | Value | Unit  |
 | :- | :- | :- |
 | Reference pressure | 211.9 | $kPa$ |
@@ -196,5 +194,70 @@ All wall surfaces are assumed to have no-slip velocity boundary condition and ad
 | Mean flow velocity at Reynolds number at hot duct | 41.48 | $m/s$ |
 | Reynolds number at hot duct | 3.1137×104 | $-$ |
 
+All wall surfaces are assumed to have no-slip velocity boundary condition and adiabatic thermal boundary condition. And a natural pressure condition is given to the outlet face of hot duct. The CFD simulations were carried out in a dimensionless manner. The reference velocity is the mean flow velocity at hot duct, which is 41.48 m/s. Normalization of temperature is accomplished by referencing it to the maximum inlet temperature of 984.34 K at CG0 group and the minimum inlet temperature of 810.05 K at the outer bypass group. Subsequently, during the post-processing stage, it is straightforward to convert the computational fluid dynamics (CFD) outcomes back into dimensional values, enabling additional analyses to be conducted.
 
-The mean LP pressure is 100.5 $kPa$, with which the helium gas has a density of 0.1004 $kg/m^3$. A non-dimensionalization process is performed for the Nek5000 calculations. The reference velocity is 3.47 $m/s$ that is the highest inlet velocity observed for Ring 3 inlet channels. The temperature difference with respect to the side reflector wall temperature (452.37 $K$) is normalized by $\Delta T = 562.20-452.37 = 109.83 (K)$, where the maximum temperature is from Ring 1 inlet channels. During the post-processing, the CFD results can be easily converted back to dimensional quantities for further analyses.
+!table id=inlet_bc caption=Inlet boundary conditions for the HTTF lower plenum simulations.
+| Zone ID | Velocity ($m/s$) | Temperature ($K$)  |
+| :- | :- | :- |
+| CG0 | 30.389 | 984.34 |
+| CG-1A | 23.513 | 924.658 |
+| CG-2A | 25.709 | 889.08 |
+| CG-3A | 26.618 | 944.901 |
+| CG-4A | 26.405 | 926.654 |
+| CG-5A | 21.83 | 866.424 |
+| CG-1B | 23.513 | 925.415 |
+| CG-2B | 25.69 | 890.425 |
+| CG-3B | 26.61 | 947.609 |
+| CG-4B | 26.446 | 932.229 |
+| CG-5B | 21.828 | 867.567 |
+| CG-1C | 23.511 | 924.788 |
+| CG-2C | 25.702 | 889.276 |
+| CG-3C | 26.608 | 945.155 |
+| CG-4C | 26.394 | 926.902 |
+| CG-5C | 21.825 | 866.606 |
+| CG-1D | 23.52 | 922.995 |
+| CG-2D | 25.794 | 886.395 |
+| CG-3D | 26.772 | 941.098 |
+| CG-4D | 26.586 | 922.794 |
+| CG-5D | 21.91 | 863.558 |
+| CG-1E | 23.517 | 920.054 |
+| CG-2E | 25.9 | 881.331 |
+| CG-3E | 27.101 | 932.826 |
+| CG-4E | 27.129 | 913.384 |
+| CG-5E | 22.303 | 856.71 |
+| CG-1F | 23.521 | 922.956 |
+| CG-2F | 25.796 | 886.341 |
+| CG-3F | 26.775 | 941.027 |
+| CG-4F | 26.589 | 922.725 |
+| CG-5F | 21.911 | 863.508 |
+| Outer bypass | 20.669 | 810.051 |
+
+!media httf/lower_plenum_cfd/new_inlet_bc.png
+       style=width:75%
+       id=new_bc
+       caption=Boundary conditions: (a) prescribed inlet velocity and no-slip wall condition; (b) prescribed inlet temperature and adiabatic walls.
+
+### NekRS case setups style=font-size:125%
+
+Readers can access the nekRS case files and the corresponding mesh files in the VTB repository via GitHub Large File Storage (LFS). The mesh data is contained in two files: +httf.re2+ (which includes grid coordinates and sideset ids) and +httf.co2+ (containing mesh cell connectivity information).
+Regarding the nekRS case files, there are four basic files:
+
+- +httf.udf+ serves as the primary nekRS kernel file and encompasses algorithms executed on the hosts. It's responsible for configuring RANS model settings, collecting time-averaged statistics, and determining the frequency of calls to +userchk+, which is defined in the +usr+ file.
+- +httf.oudf+ is a supplementary file housing kernel functions for devices and also plays a role in specifying boundary conditions..
+- +httf.usr+ s a legacy file inherited from Nek5000 and can be utilized to establish initial conditions and define post-processing capabilities.
+- +httf.par+  is employed to input simulation parameters, including material properties, time step size, and Reynolds number.
+
+There are also supportive scripts in the case folder. +linearize_bad_elements.f+ and +BAD_ELEMENTS+ are used to fix the mesh cells that potentially have negative Jacobian values from the quadratic tet-to-hex conversion. 
+Data file +InletProf.dat+ contains the fully developed turbulence solutions of a circular pipe, which is used to customize the profiles of velocity, TKE and tau at HTTF inlet channels. 
+
+Now let's dive into the most important case file +httf.usr+. The sideset ids contained in the mesh file are first translated into CFD boundary condition settings in +usrdat2+ block
+
+!listing htgr/httf/lower_plenum_mixing/nekrs_case/httf.usr start=subroutine usrdat2() end=subroutine usrdat3 include-end=False
+
+The $k-\tau$ URANS model is specified in the following code block
+
+!listing htgr/httf/lower_plenum_mixing/httf.usr start=subroutine usrdat3() end=subroutine turb_in(wd,tke,tau) include-end=False
+
+The specific inlet temperature and mass flow rates are implemented in +userbc+ with the non-dimensionalized values
+
+!listing htgr/httf/lower_plenum_mixing/httf.usr start=if(id_face.eq.3) end=endif include-end=True

--- a/doc/content/htgr/httf/lower_plenum_cfd.md
+++ b/doc/content/htgr/httf/lower_plenum_cfd.md
@@ -169,7 +169,7 @@ In the era of Exascale computing, there's a notable shift towards accelerated co
 
 ### Boundary conditions style=font-size:125%
 
-The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories. The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m3 with a reference temperature of 895.7 K. 
+The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories [!citep](Podila2022). The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m3 with a reference temperature of 895.7 K. 
 [he_condition] summarizes the key thermophysical properties of helium flow used in the NekRS simulations.  The 234 inlet channels are divided into 32 groups here as shown in [new_grouping] 
 based on the radial locations and polar angles, and each group with specific mass flow rate and temperature. Inlet channels within a certain group are assumed to have the same inflow velocity corresponding to the specific mass flow rate. 
 Details of the inlet boundary conditions are listed in [inlet_bc].

--- a/doc/content/htgr/httf/lower_plenum_cfd.md
+++ b/doc/content/htgr/httf/lower_plenum_cfd.md
@@ -80,7 +80,7 @@ Inlet channels within a specific ring are assumed to have fixed inflow velocity 
 
 The mean LP pressure is 100.5 $kPa$, with which the helium gas has a density of 0.1004 $kg/m^3$. A non-dimensionalization process is performed for the Nek5000 calculations. The reference velocity is 3.47 $m/s$ that is the highest inlet velocity observed for Ring 3 inlet channels. The temperature difference with respect to the side reflector wall temperature (452.37 $K$) is normalized by $\Delta T = 562.20-452.37 = 109.83 (K)$, where the maximum temperature is from Ring 1 inlet channels. During the post-processing, the CFD results can be easily converted back to dimensional quantities for further analyses.
 
-### Nek5000 sase setups style=font-size:125%
+### Nek5000 case setups style=font-size:125%
 
 The reader can find the Nek5000 case files and the associated HTTF lower plenum mesh files (through github LFS) in VTB repository. The mesh information is contained in two files: +httf.re2+ (grid coordinates, sideset ids, etc.) and +httf.co2+ (mesh cell connectivity).
 As for the Nek5000 case files, there are +SIZE+, +httf.par+, +httf.usr+, and two auxiliary files +limits.f+ and +utilities.f+ that hosts various post-processing functions, such as solution monitoring, planar averaging, and so forth.
@@ -169,7 +169,7 @@ In the era of Exascale computing, there's a notable shift towards accelerated co
 
 ### Boundary conditions style=font-size:125%
 
-The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories [!citep](Podila2022). The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m3 with a reference temperature of 895.7 K. 
+The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories [!citep](Podila2022). The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m$^3$ with a reference temperature of 895.7 K. 
 [he_condition] summarizes the key thermophysical properties of helium flow used in the NekRS simulations.  The 234 inlet channels are divided into 32 groups here as shown in [new_grouping] 
 based on the radial locations and polar angles, and each group with specific mass flow rate and temperature. Inlet channels within a certain group are assumed to have the same inflow velocity corresponding to the specific mass flow rate. 
 Details of the inlet boundary conditions are listed in [inlet_bc].
@@ -186,13 +186,13 @@ Details of the inlet boundary conditions are listed in [inlet_bc].
 | Reference pressure | 211.9 | $kPa$ |
 | Reference temperature | 895.7 | $K$ |
 | Helium density | 0.1075 | $kg/m^3$ |
-| Helium heat capacity | 5.193×103 | $J/kg-K$ |
-| Helium viscosity | 4.274×10-5 | $Pa-s$ |
+| Helium heat capacity | 5.193×10$^3$ | $J/kg-K$ |
+| Helium viscosity | 4.274×10$^{-5}$ | $Pa-s$ |
 | Helium thermal conductivity | 0.3323 | $W/m-K$ |
 | Helium Prandtl number | 0.67 | $-$ |
 | Hot duct diameter | 0.2984 | $m$ |
 | Mean flow velocity at Reynolds number at hot duct | 41.48 | $m/s$ |
-| Reynolds number at hot duct | 3.1137×104 | $-$ |
+| Reynolds number at hot duct | 3.1137×10$^4$ | $-$ |
 
 All wall surfaces are assumed to have no-slip velocity boundary condition and adiabatic thermal boundary condition. And a natural pressure condition is given to the outlet face of hot duct. The CFD simulations were carried out in a dimensionless manner. The reference velocity is the mean flow velocity at hot duct, which is 41.48 m/s. Normalization of temperature is accomplished by referencing it to the maximum inlet temperature of 984.34 K at CG0 group and the minimum inlet temperature of 810.05 K at the outer bypass group. Subsequently, during the post-processing stage, it is straightforward to convert the computational fluid dynamics (CFD) outcomes back into dimensional values, enabling additional analyses to be conducted.
 
@@ -243,8 +243,8 @@ Readers can access the nekRS case files and the corresponding mesh files in the 
 Regarding the nekRS case files, there are four basic files:
 
 - +httf.udf+ serves as the primary nekRS kernel file and encompasses algorithms executed on the hosts. It's responsible for configuring RANS model settings, collecting time-averaged statistics, and determining the frequency of calls to +userchk+, which is defined in the +usr+ file.
-- +httf.oudf+ is a supplementary file housing kernel functions for devices and also plays a role in specifying boundary conditions..
-- +httf.usr+ s a legacy file inherited from Nek5000 and can be utilized to establish initial conditions and define post-processing capabilities.
+- +httf.oudf+ is a supplementary file housing kernel functions for devices and also plays a role in specifying boundary conditions.
+- +httf.usr+ is a legacy file inherited from Nek5000 and can be utilized to establish initial conditions and define post-processing capabilities.
 - +httf.par+  is employed to input simulation parameters, including material properties, time step size, and Reynolds number.
 
 There are also supportive scripts in the case folder. +linearize_bad_elements.f+ and +BAD_ELEMENTS+ are used to fix the mesh cells that potentially have negative Jacobian values from the quadratic tet-to-hex conversion. 

--- a/doc/content/htgr/httf/lower_plenum_cfd.md
+++ b/doc/content/htgr/httf/lower_plenum_cfd.md
@@ -1,4 +1,4 @@
-# Nek5000 CFD Modeling of HTTF Lower Plenum Flow Mixing Phenomenon
+# Nek5000/RS CFD Modeling of HTTF Lower Plenum Flow Mixing Phenomenon
 
 *Contact: Jun Fang, fangj.at.anl.gov*
 
@@ -8,7 +8,11 @@
 
 Accurate modeling and simulation capabilities are becoming increasingly important to speed up the development and deployment of advanced nuclear reactor technologies, such as high temperature gas-cooled reactors. Among the identified safety-relevant phenomena for the gas-cooled reactors (GCR), the outlet plenum flow distribution was ranked to be of high importance with a low knowledge level in the phenomenon identification and ranking table (PIRT) [!citep](Ball2008).
 The heated coolant (e.g., helium) flows downward through the GCR core region and enters the outlet/lower plenum through narrow channels, which causes the jetting of the gas flow. The jets have a non-uniform temperature and risk yielding high cycling thermal stresses in the lower plenum, negative pressure gradients opposing the flow ingress, and hot streaking.
-These phenomena cannot be accurately captured by 1-D system codes; instead, the modeling requires using higher fidelity CFD codes that can predict the temperature fluctuations in the HTTF lower plenum. In this study, a detailed CFD model is established for the lower plenum of scaled, electrically-heated GCR test facility (i.e., High Temperature Test Facility, or HTTF) at Oregon State University. Specifically, the flow mixing phenomenon in HTTF lower plenum is simulated with spectral element CFD software, Nek5000, with the turbulence modeled by the two-equation $k-\tau$ URANS model. The velocity and temperature fields are examined to understand the thermal-fluid physics happening during the lower plenum mixing. As part of the HTTF international benchmark campaign, the simulation results generated from this study will be used for code-to-code and code-to-data comparisons in the near future, which would lay a solid foundation for the use of CFD in GCR research and development.
+These phenomena cannot be accurately captured by 1-D system codes; instead, the modeling requires using higher fidelity CFD codes that can predict the temperature fluctuations in the HTTF lower plenum. In this study, a detailed CFD model is established for the lower plenum of scaled, electrically-heated GCR test facility (i.e., High Temperature Test Facility, or HTTF) at Oregon State University. 
+Specifically, the flow mixing phenomenon in HTTF lower plenum is simulated with spectral element CFD software, +Nek5000+ and its GPU-oriented variant +nekRS+.
+The turbulence effects are modeled by the two-equation $k-\tau$ URANS model. 
+Two sets of boundary conditions are studied in the Nek5000 and nekRS simulations, respectively. 
+The velocity and temperature fields are examined to understand the thermal-fluid physics happening during the lower plenum mixing. As part of the HTTF international benchmark campaign, the simulation results generated from this study will be used for code-to-code and code-to-data comparisons in the near future, which would lay a solid foundation for the use of CFD in GCR research and development.
 
 !alert note
 This documentation assumes that the reader has basic knowledge of Nek5000, and is able to run
@@ -17,10 +21,11 @@ The specific Nek5000 version used here is v19.0. Although Nek5000 input files ar
 in the Moose CI test suite, Nek5000 does offer reliable backward compatibility.
 No foreseeable compatibility issues are expected. In rare situations where there is indeed a compatibility
 issue, please reach out to the Nek5000 developer team
-via [Nek5000 Google Group](https://groups.google.com/g/nek5000).
+via [Nek5000 Google Group](https://groups.google.com/g/nek5000). Meanwhile, nekRS code is still under active
+development, and there is only a beta version of [nekRS online tutorial](https://nekrsdoc.readthedocs.io/en/latest/index.html).
 
 
-## Simulation Setups
+## Geometry and Meshing
 
 The HTTF lower plenum (i.e., core outlet plenum) geometry is illustrated in [lp_geom], which  contains 163 ceramic cylindrical posts on which the core structure stands.
 It is enclosed by lower side reflectors, lower plenum floor and lower plenum roof. The height of the lower plenum is 22.2 $cm$. Helium gas enters the lower plenum through core coolant channels and exits through the horizontal hot duct. There are 234 inlet channels with the same diameter of 1 $in$ (i.e., 2.54 $cm$).
@@ -31,8 +36,8 @@ A cylindrical hot duct is connected to the lower plenum, which functions as the 
        id=lp_geom
        caption=Overview of the HTTF lower plenum geometry.
 
-Nek5000 requires a pure hexahedral mesh to perform the calculations. Due to the domain complexity, it is challenging to create an unstructured mesh with only hexahedral cells.
-A two-step approach is adopted in the meshing practice. We first used the commercial software, ANSYS Mesh, to generate an unstructured computational mesh consisting of tetrahedra cells (in the bulk) and wedge cells (in the boundary layer region), and then converted it into a pure hexahedra mesh using a native tet-to-hex Nek5000 utility.
+Nek5000/RS requires a pure hexahedral mesh to perform the calculations. Due to the domain complexity, it is challenging to create an unstructured mesh with only hexahedral cells.
+A two-step approach is adopted in the meshing practice. We first used the commercial software, ANSYS Mesh, to generate an unstructured computational mesh consisting of tetrahedra cells (in the bulk) and wedge cells (in the boundary layer region), and then converted it into a pure hexahedra mesh using a native quadratic tet-to-hex utility.
 To ensure the accuracy of wall-resolved RANS calculations, the first layer of grid points off the wall is kept at a distance of $y^+ < 1.0$.
 As shown in [lp_mesh], the resulting mesh has 2.60 million cells, and the total degrees of freedom is approximately 72.86 million in Nek5000 simulations with a polynomial order of 3. Note that the polynomial order is kept relatively low to limit the computational costs. It can be readily increased for higher-fidelity simulations, such as a Large Eddy Simulation (LES), given necessary computing hours.
 
@@ -41,8 +46,11 @@ As shown in [lp_mesh], the resulting mesh has 2.60 million cells, and the total 
        id=lp_mesh
        caption=The hexahedral mesh of HTTF lower plenum from the tet-to-hex conversion.
 
-The boundary conditions of the current CFD cases are taken from the corresponding system modeling of HTTF system using RELAP5-3D [!citep](Halsted2022).
+## Nek5000 Investigation
 
+### Boundary conditions style=font-size:125%
+
+The boundary conditions adopted in the Nek5000 simulations are taken from the corresponding system modeling of HTTF system using RELAP5-3D [!citep](Halsted2022).
 The 234 inlet channels are divided into five rings as shown in [lp_bcs] based on the radial locations, and each ring with specific mass flow rate and temperature.
 Inside the lower plenum (LP), the floor, roof, posts and side reflector walls all have distinct temperature values. The LP roof has the highest temperature while the side walls sees the lowest.
 Details of the thermal boundary conditions are listed in [lp_bcs_table].
@@ -72,7 +80,7 @@ Inlet channels within a specific ring are assumed to have fixed inflow velocity 
 
 The mean LP pressure is 100.5 $kPa$, with which the helium gas has a density of 0.1004 $kg/m^3$. A non-dimensionalization process is performed for the Nek5000 calculations. The reference velocity is 3.47 $m/s$ that is the highest inlet velocity observed for Ring 3 inlet channels. The temperature difference with respect to the side reflector wall temperature (452.37 $K$) is normalized by $\Delta T = 562.20-452.37 = 109.83 (K)$, where the maximum temperature is from Ring 1 inlet channels. During the post-processing, the CFD results can be easily converted back to dimensional quantities for further analyses.
 
-## Nek5000 Modelling
+### Nek5000 sase setups style=font-size:125%
 
 The reader can find the Nek5000 case files and the associated HTTF lower plenum files (through github LFS) in VTB repository. The mesh information is contained in two files: +httf.re2+ (grid coordinates, sideset ids, etc.) and +httf.co2+ (mesh cell connectivity).
 As for the Nek5000 case files, there are +SIZE+, +httf.par+, +httf.usr+, and two auxiliary files +limits.f+ and +utilities.f+ that hosts various post-processing functions, such as solution monitoring, planar averaging, and so forth.
@@ -93,7 +101,7 @@ The specific inlet temperature and mass flow rates are implemented in +userbc+ w
 !listing htgr/httf/lower_plenum_mixing/httf.usr start=if(id_face.eq.3) end=endif include-end=True
 
 
-## Simulation Results
+### Nek5000 results style=font-size:125%
 
 The aforementioned CFD cases were carried out on the Sawtooth supercomputer located at Idaho National Laboratory. A typical simulation job would use 64 compute nodes with 48 parallel processes per node.
 A characteristics based time-stepping has been used in the simulations to avoid the limitations imposed by the Courant-Friedrichs-Lewy
@@ -131,7 +139,7 @@ To better understand the modeling uncertainties of numerical simulations in the 
        id=Tavg
        caption=Time-averaged temperature field (non-dimensional) in the lower plenum.
 
-## Run Script
+### Nek5000 run Script style=font-size:125%
 
 To submit a Nek5000 simulation job on Sawtooth, the following batch script is used. The user can adjust the number of nodes, and number of processes per node, as well as the simulation time for any specific cases.
 
@@ -153,3 +161,40 @@ module purge
 module load intel-mpi/2018.5.288-intel-19.0.5-alnu
 mpirun ./nek5000 > logfile
 ```
+
+## NekRS Investigation
+
+We initiated our simulation efforts using the Nek5000 solver. However, we opted to transition to NekRS due to its remarkable enhancement in computational efficiency.
+In the era of Exascale computing, there's a notable shift towards accelerated computing using Graphics Processing Units (GPUs) among leadership class supercomputers. To fully harness this new heterogeneous computing hardware, NekRS emerges as an exascale-ready thermal-fluids solver for incompressible and low-Mach number flows. Like its predecessor, Nek5000, it is based on the spectral element method and is scalable to $10^5$ processors and beyond. The principal differences between Nek5000 and NekRS are that the former is based on F77/C, coupled with MPI and fast matrix-matrix product routines for performance, while the latter is based on C++ coupled with MPI and OCCA kernels for GPU support. The Open Concurrent Compute Abstraction provides backends for CUDA, HIP, OpenCL, and DPC++, for performance portability across all the major GPU vendors. We note that, at 80% parallel efficiency, which corresponds to 2–3 million points per MPI rank, NekRS is running at 0.1 to 0.3 seconds of wall clock time per timestep, which is nearly a 3x improvement over production runs of Nek5000 at a similar 80% strong-scale limit on CPU-based platforms.
+
+### Boundary conditions style=font-size:125%
+
+The boundary conditions of the nekRS study are taken from the corresponding system modeling of HTTF primary loop using RELAP5-3D conducted by Canadian Nuclear Laboratories. The reference lower plenum pressure is 211.9 kPa, and the helium gas has a density of 0.1950 kg/m3 with a reference temperature of 895.7 K. 
+Table 3 summarizes the key thermophysical properties of helium flow used in the NekRS simulations.  The 234 inlet channels are divided into 32 groups here as shown in [new_grouping] 
+based on the radial locations and polar angles, and each group with specific mass flow rate and temperature. Inlet channels within a certain group are assumed to have the same inflow velocity corresponding to the specific mass flow rate. 
+Details of the inlet boundary conditions are listed in Table 4.
+Figure 11 visually illustrates the boundary conditions that are enumerated in Table 4. 
+All wall surfaces are assumed to have no-slip velocity boundary condition and adiabatic thermal boundary condition. And a natural pressure condition is given to the outlet face of hot duct. The CFD simulations were carried out in a dimensionless manner. The reference velocity is the mean flow velocity at hot duct, which is 41.48 m/s. Normalization of temperature is accomplished by referencing it to the maximum inlet temperature of 984.34 K at CG0 group and the minimum inlet temperature of 810.05 K at the outer bypass group. Subsequently, during the post-processing stage, it is straightforward to convert the computational fluid dynamics (CFD) outcomes back into dimensional values, enabling additional analyses to be conducted.
+
+!media httf/lower_plenum_cfd/new_grouping.png
+       style=width:60%
+       id=new_grouping
+       caption=The grouping of lower plenum inlet channels.
+
+
+!table id=new_bc caption=Helium thermo-physical properties and flow conditions.
+| $-$ | Value | Unit  |
+| :- | :- | :- |
+| Reference pressure | 211.9 | $kPa$ |
+| Reference temperature | 895.7 | $K$ |
+| Helium density | 0.1075 | $kg/m^3$ |
+| Helium heat capacity | 5.193×103 | $J/kg-K$ |
+| Helium viscosity | 4.274×10-5 | $Pa-s$ |
+| Helium thermal conductivity | 0.3323 | $W/m-K$ |
+| Helium Prandtl number | 0.67 | $-$ |
+| Hot duct diameter | 0.2984 | $m$ |
+| Mean flow velocity at Reynolds number at hot duct | 41.48 | $m/s$ |
+| Reynolds number at hot duct | 3.1137×104 | $-$ |
+
+
+The mean LP pressure is 100.5 $kPa$, with which the helium gas has a density of 0.1004 $kg/m^3$. A non-dimensionalization process is performed for the Nek5000 calculations. The reference velocity is 3.47 $m/s$ that is the highest inlet velocity observed for Ring 3 inlet channels. The temperature difference with respect to the side reflector wall temperature (452.37 $K$) is normalized by $\Delta T = 562.20-452.37 = 109.83 (K)$, where the maximum temperature is from Ring 1 inlet channels. During the post-processing, the CFD results can be easily converted back to dimensional quantities for further analyses.

--- a/doc/content/htgr/index.md
+++ b/doc/content/htgr/index.md
@@ -16,7 +16,7 @@
 
 [RELAP-7 High Temperature Test Facility (HTTF) model](httf/index.md)
 
-[Nek5000 HTTF lower plenum flow mixing model](httf/lower_plenum_cfd.md)
+[Nek5000/RS HTTF lower plenum CFD model](httf/lower_plenum_cfd.md)
 
 [SAM Generic Pebble Bed HTGR model](generic-pbr/index.md)
 

--- a/doc/content/media/httf/lower_plenum_cfd/.gitattributes
+++ b/doc/content/media/httf/lower_plenum_cfd/.gitattributes
@@ -1,0 +1,6 @@
+new_T_LPfloor.png filter=lfs diff=lfs merge=lfs -text
+new_T_slice_view.png filter=lfs diff=lfs merge=lfs -text
+new_averaged_T.png filter=lfs diff=lfs merge=lfs -text
+new_averaged_U.png filter=lfs diff=lfs merge=lfs -text
+new_grouping.png filter=lfs diff=lfs merge=lfs -text
+new_inlet_bc.png filter=lfs diff=lfs merge=lfs -text

--- a/doc/content/media/httf/lower_plenum_cfd/new_T_LPfloor.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_T_LPfloor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b05e1f37d4fa300591a45f2cce474852c17b721fbbf831be91ee12530da18722
+size 1682671

--- a/doc/content/media/httf/lower_plenum_cfd/new_T_slice_view.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_T_slice_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:335a508a1747963f6f04bb56c2986fcafe3d3c8db46232984154d6cca601e9ab
+size 1592923

--- a/doc/content/media/httf/lower_plenum_cfd/new_averaged_T.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_averaged_T.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15003d869a99d304a579478f3950e043e6cfd4f09962dc441177e2074c09d794
+size 2324992

--- a/doc/content/media/httf/lower_plenum_cfd/new_averaged_U.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_averaged_U.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c94d4b74e672c17dbc1075cd807be665506b1d345e66b6062d858a404a88e25
+size 3695799

--- a/doc/content/media/httf/lower_plenum_cfd/new_grouping.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_grouping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0578a6e5f44a5427228c6de80b1366493682112d197c171e20f1560ac5e8febc
+size 374594

--- a/doc/content/media/httf/lower_plenum_cfd/new_inlet_bc.png
+++ b/doc/content/media/httf/lower_plenum_cfd/new_inlet_bc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d6ba7c5af94dc600d62743d9e8a21acef607eebfe97c17356f947740f9b362
+size 6554325

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/.gitattributes
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/.gitattributes
@@ -1,0 +1,2 @@
+httf.re2 filter=lfs diff=lfs merge=lfs -text
+httf.co2 filter=lfs diff=lfs merge=lfs -text

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/BAD_ELEMENTS
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/BAD_ELEMENTS
@@ -1,0 +1,15 @@
+      parameter(nbad_max=10000)
+      real bad_list(lelt)
+      real e12(3,12),ecenter(3),elength
+      real bad_xyzr(4,nbad_max),work_array(4*nbad_max)
+
+	  integer inje_rank,nnje_rank  ! number of bad elements in this ranks
+	  real bad_eg_list(lelg)        ! bad elements eg list in this rank
+      real work_array2(lelg)
+      integer sbad_eg_list(nbad_max)
+      real minJac
+
+      common /bad_elements/ bad_list,e12,ecenter,elength,
+     & bad_xyzr,work_array,
+     & inje_rank,nnje_rank,bad_eg_list,work_array2,
+     & sbad_eg_list,minJac

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.co2
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.co2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da1f94d8904c9b5a485b96252c4c2b96cdfd968a13098a251fd72526d6a1e90
+size 93483532

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.oudf
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.oudf
@@ -1,0 +1,45 @@
+@kernel void scalarScaledAdd(const dlong N,
+                             const dfloat a,
+                             const dfloat b,
+                             @restrict const dfloat* X,
+                             @restrict dfloat* Y)
+{
+  for(dlong n = 0; n < N; ++n; @tile(256,@outer,@inner))
+    if(n < N)
+      Y[n] = a + b * X[n];
+}
+
+@kernel void cliptOKL(const dlong Nelements,
+                   @restrict dfloat * TEMP)
+{
+ for(dlong e=0;e<Nelements;++e;@outer(0)){
+   for(int n=0;n<p_Np;++n;@inner(0)){
+     const int id = e*p_Np + n;
+     if(TEMP[id]>1.0)
+          {
+          TEMP[id] = 1.0;
+          }
+     if(TEMP[id]<0.0)
+          {
+          TEMP[id] = 0.0;
+          }
+   }
+ }
+}
+
+void velocityDirichletConditions(bcData *bc)
+{
+  bc->u = 0.0;
+  bc->v = bc->usrwrk[bc->idM + 0*bc->fieldOffset];
+  bc->w = 0.0;
+}
+
+void scalarDirichletConditions(bcData *bc)
+{
+  bc->s = 0;
+  if(bc->id==1){
+    if(bc->scalarId == 0) bc->s = bc->usrwrk[bc->idM + 1*bc->fieldOffset];
+    if(bc->scalarId == 1) bc->s = bc->usrwrk[bc->idM + 2*bc->fieldOffset];
+    if(bc->scalarId == 2) bc->s = bc->usrwrk[bc->idM + 3*bc->fieldOffset];
+  } 
+}

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.par
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.par
@@ -1,0 +1,47 @@
+[GENERAL]
+polynomialOrder = 3
+#startFrom = "httf.run01"+time=0
+startFrom = httf.run03
+stopAt = endTime
+endTime = 6
+#numSteps = 5
+dt = targetCFL=4 + initial=1e-5
+timeStepper = tombo2
+writeControl = simulationTime 
+writeInterval = 0.1
+
+#verbose=true
+
+[PROBLEMTYPE]
+equation = navierStokes+variableViscosity
+
+[MESH]
+writeToFieldFile = yes
+
+[PRESSURE]
+residualTol = 1e-04
+
+[VELOCITY]
+boundaryTypeMap = v,W,o 
+residualTol = 1e-06
+density = 1.0
+viscosity = -104331.27 
+
+[TEMPERATURE]
+#solver = none
+boundaryTypeMap = t,I,o
+residualTol = 1e-06
+rhoCp = 1.0
+conductivity = -69683.01 
+
+[SCALAR01] # k
+boundaryTypeMap = t,t,o 
+residualTol = 1e-06
+rho = 1.0
+diffusivity = -104331.27 
+
+[SCALAR02] # tau
+boundaryTypeMap = t,t,o
+residualTol = 1e-06
+rho = 1.0
+diffusivity = -104331.27 

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.re2
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.re2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68bfe95fb8eb272528a9f41b5b8b5e14c1e729f85ff31ba85437c7f63f6bc7f5
+size 834356844

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.udf
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.udf
@@ -1,0 +1,88 @@
+//
+// nekRS User Defined File
+//
+#include "udf.hpp"
+#include "plugins/RANSktau.hpp"
+#include "plugins/tavg.hpp"
+
+static dfloat rho, mueLam;
+static occa::kernel scalarScaledAddKernel;
+static occa::kernel cliptKernel;
+
+void userq(nrs_t *nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
+{
+  mesh_t *mesh = nrs->meshV;
+  cds_t *cds   = nrs->cds;
+
+  RANSktau::updateSourceTerms();
+}
+
+void uservp(nrs_t *nrs, dfloat time, occa::memory o_U, occa::memory o_S,
+            occa::memory o_UProp, occa::memory o_SProp)
+{
+  mesh_t *mesh = nrs->meshV;
+  cds_t *cds   = nrs->cds;
+
+  RANSktau::updateProperties();
+
+  dfloat conductivity;
+  platform->options.getArgs("SCALAR00 DIFFUSIVITY", conductivity);
+  const dfloat Pr_t = 0.91;
+  occa::memory o_mue_t = RANSktau::o_mue_t();
+  occa::memory o_temp_mue = cds->o_diff + 0*cds->fieldOffset[0]*sizeof(dfloat);
+  scalarScaledAddKernel(mesh->Nlocal, conductivity, 1/Pr_t, o_mue_t, o_temp_mue);
+}
+
+void UDF_LoadKernels(occa::properties& kernelInfo)
+{
+  scalarScaledAddKernel = oudfBuildKernel(kernelInfo, "scalarScaledAdd");
+  cliptKernel  = oudfBuildKernel(kernelInfo, "cliptOKL");
+  RANSktau::buildKernel(kernelInfo);
+}
+
+void UDF_Setup(nrs_t *nrs)
+{
+  tavg::setup(nrs);
+
+  mesh_t *mesh = nrs->meshV;
+  cds_t *cds = nrs->cds;
+
+  udf.properties = &uservp;
+  udf.sEqnSource = &userq;
+
+  const int scalarFieldStart = 1;
+  platform->options.getArgs("VISCOSITY", mueLam); 
+  platform->options.getArgs("DENSITY", rho); 
+
+  RANSktau::setup(nrs, mueLam, rho, scalarFieldStart);
+
+  //Inlet condition
+  nrs->o_usrwrk = platform->device.malloc(4*nrs->fieldOffset,sizeof(dfloat));
+  double *vin  = (double *) nek::scPtr(1);
+  double *t1in = (double *) nek::scPtr(2);
+  double *t2in = (double *) nek::scPtr(3);
+  double *t3in = (double *) nek::scPtr(4);
+  nrs->o_usrwrk.copyFrom(vin, mesh->Nlocal*sizeof(dfloat),0*nrs->fieldOffset*sizeof(dfloat));
+  nrs->o_usrwrk.copyFrom(t1in,mesh->Nlocal*sizeof(dfloat),1*nrs->fieldOffset*sizeof(dfloat));
+  nrs->o_usrwrk.copyFrom(t2in,mesh->Nlocal*sizeof(dfloat),2*nrs->fieldOffset*sizeof(dfloat));
+  nrs->o_usrwrk.copyFrom(t3in,mesh->Nlocal*sizeof(dfloat),3*nrs->fieldOffset*sizeof(dfloat));
+}
+
+void UDF_ExecuteStep(nrs_t *nrs, dfloat time, int tstep)
+{
+  tavg::run(time);
+
+  mesh_t *mesh = nrs->meshV;
+  cds_t *cds = nrs->cds;
+  
+  cliptKernel(mesh->Nelements, cds->o_S);
+
+  if ((tstep%1000)==0){
+    nek::ocopyToNek(time, tstep);
+    nek::userchk();
+  }
+
+  if (nrs->isOutputStep) {
+    tavg::outfld();
+  }
+}

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/httf.usr
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/httf.usr
@@ -1,0 +1,607 @@
+c-----------------------------------------------------------------------
+C
+C  USER SPECIFIED ROUTINES: 
+C
+C     - boundary conditions 
+C     - initial conditions  
+C     - variable properties 
+C     - forcing function for fluid (f)
+C     - forcing function for passive scalar (q)
+C     - general purpose routine for checking errors etc.        
+C
+c-----------------------------------------------------------------------
+      include 'linearize_bad_elements.f'
+c-----------------------------------------------------------------------
+      subroutine useric (ix,iy,iz,ieg)
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+
+      ux   = 0.0  
+      uy   = 0.0 
+      uz   = 0.0
+
+      if (ifield.eq.2) then
+         temp = 0.0
+      elseif (ifield.eq.3) then
+         temp = 0.01
+      elseif (ifield.eq.4) then
+         temp = 0.1
+      endif
+      
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer e, f
+
+      nf=lx1*ly1*lz1*nelv
+
+      dA1 = 0.0
+      vz1 = 0.0
+      do e=1,nelv
+        dv = 0.0
+        ds = 0.0
+        do f=1,2*ndim
+           if (cbc(f,e,1).eq.'v  ') then
+               call surface_int(dv,ds,vy,e,f)
+               vz1= vz1 + dv
+               dA1 = dA1 + ds
+           endif
+        enddo
+      enddo
+      vz1 = glsum(vz1,1)
+      dA1 = glsum(dA1,1)
+      vz1 = vz1/dA1
+
+      dA2 = 0.0
+      vz2 = 0.0
+      do e=1,nelv
+        dv = 0.0
+        ds = 0.0
+        do f=1,2*ndim
+           if (cbc(f,e,1).eq.'o  ') then
+              call surface_int(dv,ds,vx,e,f)
+              vz2= vz2 + dv
+              dA2 = dA2 + ds
+           endif
+        enddo
+      enddo
+      vz2 = glsum(vz2,1)
+      dA2 = glsum(dA2,1)
+      vz2 = vz2/dA2
+
+      if (nid.eq.0) then
+        write(6,'(a15,es13.4)') "U_mean_in:",vz1
+        write(6,'(a15,es13.4)') "A_in:",dA1
+        write(6,'(a15,es13.4)') "U_mean_out:",vz2
+        write(6,'(a15,es13.4)') "A_out:",dA2
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat   ! This routine to modify element vertices
+      include 'SIZE'      ! _before_ mesh is generated, which 
+      include 'TOTAL'     ! guarantees GLL mapping of mesh.
+
+      integer n_correction
+      real minJacobian
+ 
+      n_correction = 2
+      call linearize_bad_elements(n_correction)  ! 2 (iterations for correction) should be enough, if not, set to 3
+
+      minScaleJacobian = 1e-3
+      call linearize_low_jacobian_elements(n_correction,
+     & minScaleJacobian) ! linearize element that with lower jacobian than minJacobian
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat2()  ! This routine to modify mesh coordinates
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer iel, ifc, id_face
+      integer i, e, f
+
+      do iel=1,nelv
+      do ifc=1,2*ndim
+        id_face = bc(5,ifc,iel,1)
+        if (id_face.ge.5.and.id_face.le.11) then        !CG0-CG5 and OB
+           cbc(ifc,iel,1) = 'v  '
+           boundaryID(ifc,iel)  = 1
+           boundaryIDt(ifc,iel) = 1
+        elseif (id_face.eq.4) then 			!walls
+           cbc(ifc,iel,1) = 'W  '
+           boundaryID(ifc,iel)  = 2
+           boundaryIDt(ifc,iel) = 2
+        elseif (id_face.eq.3) then                 	!outlet
+           cbc(ifc,iel,1) = 'o  '
+           boundaryID(ifc,iel)  = 3
+           boundaryIDt(ifc,iel) = 3
+        else
+           cbc(ifc,iel,1) = 'E  '
+           boundaryID(ifc,iel)  = 0
+           boundaryIDt(ifc,iel) = 0
+        endif
+      enddo
+      enddo
+
+      do i=2,ldimt1
+      do e=1,nelt
+      do f=1,ldim*2
+        cbc(f,e,i)=cbc(f,e,1)
+        if(cbc(f,e,1).eq.'W  ') then
+           cbc(f,e,i)='t  '
+           if(i.eq.2) cbc(f,e,i)='I  '	!Insulated temp BC on walls
+        endif
+        if(cbc(f,e,1).eq.'v  ') cbc(f,e,i)='t  '
+        if(cbc(f,e,1).eq.'o  ') cbc(f,e,i)='o  '
+      enddo
+      enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat3
+      include 'SIZE'
+      include 'TOTAL'
+
+      real uin,vin,win,tin
+      common /inarrs/
+     $     vin(lx1,ly1,lz1,lelv),
+     $     t1in(lx1,ly1,lz1,lelv),
+     $     t2in(lx1,ly1,lz1,lelv),
+     $     t3in(lx1,ly1,lz1,lelv)
+
+      real w1,w2,w3,w4,w5
+      common /SCRNS/
+     &      w1(lx1*ly1*lz1*lelv)
+     &     ,w2(lx1*ly1*lz1*lelv)
+     &     ,w3(lx1*ly1*lz1*lelv)
+     &     ,w4(lx1*ly1*lz1*lelv)
+     &     ,w5(lx1*ly1*lz1*lelv)
+
+      common /NRSSCPTR/ nrs_scptr(10)
+      integer*8 nrs_scptr
+
+      common /mywalldist/ ywd(lx1,ly1,lz1,lelt)
+      real ywd
+
+      if(istep.eq.0)then
+         call distf(ywd,1,'W  ',w1,w2,w3,w4,w5)
+         call getinlet
+         nrs_scptr(1) = loc(vin(1,1,1,1))
+         nrs_scptr(2) = loc(t1in(1,1,1,1))
+         nrs_scptr(3) = loc(t2in(1,1,1,1))
+         nrs_scptr(4) = loc(t3in(1,1,1,1))
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine getinlet
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer id_face
+
+      do ie=1,nelt
+      do ifc=1,2*ndim
+         ieg = lglel(ie)
+         id_face = bc(5,ifc,ie,1)
+         if(cbc(ifc,ie,1).eq.'v  ')then
+            CALL FACIND (KX1,KX2,KY1,KY2,KZ1,KZ2,lx1,ly1,lz1,IFC)
+            do IZ=KZ1,KZ2
+            do IY=KY1,KY2
+            do IX=KX1,KX2
+               CALL fillbc  (IX,IY,IZ,ifc,ieg,id_face)
+            enddo
+            enddo
+            enddo
+         endif
+      enddo
+      enddo
+
+      return
+      end
+c---------------------------------------------------------------------
+      subroutine fillbc(ix,iy,iz,iside,ieg,id_face)
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer ix,iy,iz,iside,ieg,e,id_face
+
+      integer icalld
+      save icalld
+      data icalld /0/
+
+      common /mywalldist/ ywd(lx1,ly1,lz1,lelt)
+      real ywd
+
+      real rpin,upin,kpin,taupin
+      real xx,zz,uig,tig
+      real uin,vin,win,tin
+      common /inarrs/
+     $     vin(lx1,ly1,lz1,lelv),
+     $     t1in(lx1,ly1,lz1,lelv),
+     $     t2in(lx1,ly1,lz1,lelv),
+     $     t3in(lx1,ly1,lz1,lelv)
+
+      e = gllel(ieg)
+
+      if(icalld.eq.0)then
+         call getInletProf
+         icalld = 1
+      endif
+
+      rpin = ywd(ix,iy,iz,e)/0.0127 !inlet diameter is 1 inch
+      if(rpin.lt.0.0)rpin = 0.0
+      if(rpin.gt.0.5)rpin = 0.5
+
+      call initprof(rpin,upin,kpin,taupin)
+
+      xx = xm1(ix,iy,iz,e)
+      zz = zm1(ix,iy,iz,e)
+      call inGrp(id_face,xx,zz,uig,tig)
+
+C rescaling is needed later on to account for the inlet differences
+      vin(ix,iy,iz,e)  =-upin*uig/1.1911099755280039 	!adjust to have U_duct of 1
+      t1in(ix,iy,iz,e) = tig
+      t2in(ix,iy,iz,e) = kpin*uig**2.0
+      t3in(ix,iy,iz,e) = taupin/uig**2.0
+
+      return
+      end
+c--------------------------------------------------------------------
+      subroutine getInletProf
+
+      include 'SIZE'
+      include 'SPLINE'
+
+      real YY(npts),ZZ(npts)
+
+      if (nid.eq.0) then
+         write(*,'(A,I4)')      'npts  = ', npts
+         write(*,'(A,1pE10.2)') 'ymin = ', ymin
+         write(*,'(A,1pE10.2)') 'ymax = ', ymax
+         write(*,'(A,1pE10.2)') 'ymin_turb = ', ymin_turb
+         write(*,'(A,1pE10.2)') 'ymax_turb = ', ymax_turb
+      endif
+
+C  Read in the 1-D profile computed by turbChan2D
+C        velocity       in fU
+C        kinetic energy in fK
+C        omega          in fO
+
+      open(unit=100,file='InletProf.dat',status='old')
+      read(100, *)     ! skip the header
+      do i=1,npts
+        read(100,*)  YY(i), fU(i), fK(i), fO(i)
+c        write(*,*)  YY(i), fU(i), fK(i), fO(i)
+      enddo
+      close(100)
+
+C  compute spline coefficients for U
+      do i=1,npts
+        ZZ(i)  = fU(i)
+        SYY(i) = YY(i)
+      enddo
+      call spline (npts, YY, ZZ, sbU, scU, sdU)
+
+C  compute spline coefficients for T
+      do i=1,npts
+        ZZ(i) = fK(i)
+      enddo
+      call spline (npts, YY, ZZ, sbK, scK, sdK)
+
+C  compute spline coefficients for species mass fractions
+      do i=1,npts
+        ZZ(i) = fO(i)
+      enddo
+      call spline (npts, YY, ZZ, sbO, scO, sdO)
+
+      return
+      end
+
+c-----------------------------------------------------------------------
+      subroutine spline (n, x, y, b, c, d)
+
+c  the coefficients b(i), c(i), and d(i), i=1,2,...,n are computed
+c  for a cubic interpolating spline
+c
+c    s(x) = y(i) + b(i)*(x-x(i)) + c(i)*(x-x(i))**2 + d(i)*(x-x(i))**3
+c
+c    for  x(i) .le. x .le. x(i+1)
+c
+c  input..
+c
+c    n = the number of data points or knots (n.ge.2)
+c    x = the abscissas of the knots in strictly increasing order
+c    y = the ordinates of the knots
+c
+c  output..
+c
+c    b, c, d  = arrays of spline coefficients as defined above.
+c
+c  using  p  to denote differentiation,
+c
+c    y(i) = s(x(i))
+c    b(i) = sp(x(i))
+c    c(i) = spp(x(i))/2
+c    d(i) = sppp(x(i))/6  (derivative from the right)
+c
+c  the accompanying function subprogram  seval  can be used
+c  to evaluate the spline.
+
+      integer n
+      real x(n), y(n), b(n), c(n), d(n)
+
+      integer nm1, ib, i
+      real t
+
+C      do i = 1, n
+C        if (nid.eq.0) write(41,'(1p2E13.5)') x(i), y(i)
+C      enddo
+C      if (nid.eq.0) write(41,'(A)') '&'
+
+      nm1 = n-1
+      if ( n .lt. 2 ) return
+      if ( n .lt. 3 ) go to 50
+
+c  set up tridiagonal system
+c  b = diagonal, d = offdiagonal, c = right hand side.
+
+      d(1) = x(2) - x(1)
+      c(2) = (y(2) - y(1))/d(1)
+      do 10 i = 2, nm1
+         d(i) = x(i+1) - x(i)
+         b(i) = 2.*(d(i-1) + d(i))
+         c(i+1) = (y(i+1) - y(i))/d(i)
+         c(i) = c(i+1) - c(i)
+   10 continue
+
+c  end conditions.  third derivatives at  x(1)  and  x(n)
+c  obtained from divided differences
+
+      b(1) = -d(1)
+      b(n) = -d(n-1)
+      c(1) = 0.0
+      c(n) = 0.0
+      if ( n .eq. 3 ) go to 15
+      c(1) = c(3)/(x(4)-x(2)) - c(2)/(x(3)-x(1))
+      c(n) = c(n-1)/(x(n)-x(n-2)) - c(n-2)/(x(n-1)-x(n-3))
+      c(1) = c(1)*d(1)**2/(x(4)-x(1))
+      c(n) = -c(n)*d(n-1)**2/(x(n)-x(n-3))
+
+c  forward elimination
+
+   15 do 20 i = 2, n
+         t = d(i-1)/b(i-1)
+         b(i) = b(i) - t*d(i-1)
+         c(i) = c(i) - t*c(i-1)
+   20 continue
+
+c  back substitution
+
+      c(n) = c(n)/b(n)
+      do 30 ib = 1, nm1
+         i = n-ib
+         c(i) = (c(i) - d(i)*c(i+1))/b(i)
+   30 continue
+
+c  c(i) is now the sigma(i) of the text
+c
+c  compute polynomial coefficients
+
+      b(n) = (y(n) - y(nm1))/d(nm1) + d(nm1)*(c(nm1) + 2.*c(n))
+      do 40 i = 1, nm1
+         b(i) = (y(i+1) - y(i))/d(i) - d(i)*(c(i+1) + 2.*c(i))
+         d(i) = (c(i+1) - c(i))/d(i)
+         c(i) = 3.*c(i)
+   40 continue
+      c(n) = 3.0*c(n)
+      d(n) = d(n-1)
+      return
+
+   50 b(1) = (y(2)-y(1))/(x(2)-x(1))
+      c(1) = 0.0
+      d(1) = 0.0
+      b(2) = b(1)
+      c(2) = 0.0
+      d(2) = 0.0
+
+      return
+      end
+c--------------------------------------------------------------------
+      subroutine initprof(y,Uin,Kin,Oin)
+c
+c Compute temperature + species using cubic splines
+c   f(y) = s(i) + sb(i)*(y-SYY(i)) + sc(i)*(y-SYY(i))**2 + sd(i)*(y-SYY(i))**3
+
+      include 'SPLINE'
+
+      real y, Uin, Kin, Oin
+
+      ii = 0
+      do i=1,npts-1
+        if (y.ge.SYY(i) .and. y.lt.SYY(i+1)) ii=i
+      enddo
+      if(abs(y-SYY(npts)).lt.1e-7) ii=npts
+
+      if (ii.le.0) then
+        write(*,*) 'Error in init_mean: ii= ', ii,'>npts=', npts, y
+        call exitt
+      endif
+
+      Uin=fU(ii) + sbU(ii)*(y-SYY(ii))
+     *     +scU(ii)*(y-SYY(ii))**2+sdU(ii)*(y-SYY(ii))**3
+
+      if (y.ge.SYY(npts)) Uin=fU(npts)
+
+      Kin=fK(ii) + sbK(ii)*(y-SYY(ii))
+     *     +scK(ii)*(y-SYY(ii))**2+sdK(ii)*(y-SYY(ii))**3
+
+      if (y.ge.SYY(npts)) Kin=fK(npts)
+
+      Oin=fO(ii) + sbO(ii)*(y-SYY(ii))
+     *     +scO(ii)*(y-SYY(ii))**2+sdO(ii)*(y-SYY(ii))**3
+
+      if (y.ge.SYY(npts)) Oin=fO(npts)
+
+      return
+      end
+c---------------------------------------------------------------------
+      subroutine inGrp(id_face,x,z,uig,tig)
+c
+c Get the mean velocity and temperature based on the HTTF inlet channel groups
+c
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer iel,ifc,id_face      
+      integer igrp
+      real x,z,theta
+
+C Calculate the polar angle
+      theta = atan2(z, x)
+    
+C Shift the angle to be between 0 and 2*pi
+      if (theta.lt.0.0) then
+        theta = theta + 2 * PI
+      endif
+    
+C Divide the plane into 6 equal area groups based on the polar angle
+      if (theta.ge.3.0*PI/2.0.and.theta.lt.11.0*PI/6.0) then
+         igrp = 1
+      elseif (theta.ge.11.0*PI/6.0.or.theta.lt.PI/6.0) then
+         igrp = 2
+      elseif (theta.ge.PI/6.0.and.theta.lt.PI/2.0) then
+         igrp = 3
+      elseif (theta.ge.PI/2.0.and.theta.lt.5.0*PI/6.0) then
+         igrp = 4
+      elseif (theta.ge.5.0*PI/6.0.and.theta.lt.7.0*PI/6.0) then
+         igrp = 5
+      else
+         igrp = 6
+      endif
+
+C Locate the channel group based igrp and id_face
+      uig = 0.0
+      tig = 0.0 
+      if (id_face.eq.5) then !CG0
+         uig = 0.732573576
+         tig = 1.0
+      elseif (id_face.eq.6) then !CG1
+         if (igrp.eq.1) then !CG1A
+            uig = 0.566817023
+            tig = 0.657568751
+         elseif (igrp.eq.2) then !CG1B
+            uig = 0.566817023
+            tig = 0.661912111
+         elseif (igrp.eq.3) then !CG1C
+            uig = 0.56676881
+            tig = 0.658314638
+         elseif (igrp.eq.4) then !CG1D
+            uig = 0.566985768
+            tig = 0.648027127
+         elseif (igrp.eq.5) then !CG1E
+            uig = 0.566913449
+            tig = 0.631152855
+         elseif (igrp.eq.6) then !CG1F
+            uig = 0.567009875
+            tig = 0.647803361
+         endif
+      elseif (id_face.eq.7) then !CG2
+         if (igrp.eq.1) then !CG2A
+            uig = 0.61975498
+            tig = 0.453436534
+         elseif (igrp.eq.2) then !CG2B
+            uig = 0.619296955
+            tig = 0.461153601
+         elseif (igrp.eq.3) then !CG2C
+            uig = 0.619586234
+            tig = 0.454561103
+         elseif (igrp.eq.4) then !CG2D
+            uig = 0.621804035
+            tig = 0.438031086
+         elseif (igrp.eq.5) then !CG2E
+            uig = 0.624359328
+            tig = 0.408975896
+         elseif (igrp.eq.6) then !CG2F
+            uig = 0.621852248
+            tig = 0.437721256
+         endif
+      elseif (id_face.eq.8) then !CG3
+         if (igrp.eq.1) then !CG3A
+            uig = 0.641667822
+            tig = 0.773714922
+         elseif (igrp.eq.2) then !CG3B
+            uig = 0.64147497
+            tig = 0.789252334
+         elseif (igrp.eq.3) then !CG3C
+            uig = 0.641426757
+            tig = 0.775172271
+         elseif (igrp.eq.4) then !CG3D
+            uig = 0.645380229
+            tig = 0.751894841
+         elseif (igrp.eq.5) then !CG3E
+            uig = 0.65331128
+            tig = 0.704433441
+         elseif (igrp.eq.6) then !CG3F
+            uig = 0.645452549
+            tig = 0.751487472
+         endif
+      elseif (id_face.eq.9) then !CG4
+         if (igrp.eq.1) then !CG4A
+            uig = 0.63653313
+            tig = 0.669020994
+         elseif (igrp.eq.2) then !CG4B
+            uig = 0.637521498
+            tig = 0.701008096
+         elseif (igrp.eq.3) then !CG4C
+            uig = 0.636267958
+            tig = 0.670443918
+         elseif (igrp.eq.4) then !CG4D
+            uig = 0.640896413
+            tig = 0.64687387
+         elseif (igrp.eq.5) then !CG4E
+            uig = 0.653986263
+            tig = 0.592883085
+         elseif (igrp.eq.6) then !CG4F
+            uig = 0.640968733
+            tig = 0.646477976
+         endif
+      elseif (id_face.eq.10) then !CG5
+         if (igrp.eq.1) then !CG5A
+            uig = 0.52624572
+            tig = 0.323445542
+         elseif (igrp.eq.2) then !CG5B
+            uig = 0.526197506
+            tig = 0.330003615
+         elseif (igrp.eq.3) then !CG5C
+            uig = 0.526125187
+            tig = 0.324489784
+         elseif (igrp.eq.4) then !CG5D
+            uig = 0.528174243
+            tig = 0.307001589
+         elseif (igrp.eq.5) then !CG5E
+            uig = 0.537648112
+            tig = 0.267710527
+         elseif (igrp.eq.6) then !CG5F
+            uig = 0.528198349
+            tig = 0.306714709
+         endif
+      elseif (id_face.eq.11) then !Outer bypass
+         uig = 0.498258029
+         tig = 0.0
+      endif
+
+      return
+      end
+c---------------------------------------------------------------------

--- a/htgr/httf/lower_plenum_mixing/nekrs_case/linearize_bad_elements.f
+++ b/htgr/httf/lower_plenum_mixing/nekrs_case/linearize_bad_elements.f
@@ -1,0 +1,602 @@
+      subroutine linearize_bad_elements(niter_corr)   ! This routine to modify element vertices
+
+c      implicit none
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      include "BAD_ELEMENTS"
+
+      integer iter, niter_corr
+
+      minJac = 0.0
+
+      do iter =1,niter_corr
+      
+	  if (nid.eq.0) write(6,*) 'linearize bad elements, iter: ', iter
+
+      call pre_check_jacobian() 
+
+      call get_bad_element_list()
+	  
+       do ie = 1,nelt
+      
+        if (bad_list(ie).gt.0) then
+		
+         call v8_to_e12(xc(1,ie),yc(1,ie),zc(1,ie),e12)
+         do ed = 1,12  ! copy linearized mid-edge point
+           curve(1,ed,ie) = e12(1,ed)
+           curve(2,ed,ie) = e12(2,ed)
+           curve(3,ed,ie) = e12(3,ed)
+         enddo
+
+        endif
+       enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine linearize_low_jacobian_elements(niter_corr,
+     & minScaleJacobian)   ! This routine to modify element vertices
+
+c      implicit none
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      include "BAD_ELEMENTS"
+
+      integer iter, niter_corr
+
+      minJac = minScaleJacobian
+
+      do iter =1,niter_corr
+      
+	  if (nid.eq.0) write(6,*) 'linearize bad elements, iter: ', iter
+
+      call pre_check_jacobian() 
+
+      call get_bad_element_list()
+	  
+       do ie = 1,nelt
+      
+        if (bad_list(ie).gt.0) then
+		
+         call v8_to_e12(xc(1,ie),yc(1,ie),zc(1,ie),e12)
+         do ed = 1,12  ! copy linearized mid-edge point
+           curve(1,ed,ie) = e12(1,ed)
+           curve(2,ed,ie) = e12(2,ed)
+           curve(3,ed,ie) = e12(3,ed)
+         enddo
+
+        endif
+       enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine pre_check_jacobian() 
+c 
+c 
+c      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+
+      COMMON /SCRUZ/ XM3 (LX3,LY3,LZ3,LELT)
+     $ ,             YM3 (LX3,LY3,LZ3,LELT)
+     $ ,             ZM3 (LX3,LY3,LZ3,LELT)
+
+
+       CALL LAGMASS
+       CALL GENCOOR (XM3,YM3,ZM3)
+       call fix_geom_pre_check() ! ?
+       CALL geom1_chk_jac(XM3,YM3,ZM3)
+
+      return
+      end
+c -----------------------------------------------------------------------
+      subroutine geom1_chk_jac (xm3,ym3,zm3)
+C
+C     Routine to generate all elemental geometric data for mesh 1.
+C
+C     Velocity formulation : global-to-local mapping based on mesh 3
+C     Stress   formulation : global-to-local mapping based on mesh 1
+C
+C-----------------------------------------------------------------------
+      INCLUDE 'SIZE'
+      INCLUDE 'GEOM'
+      INCLUDE 'INPUT'
+      INCLUDE 'TSTEP'
+C
+C     Note : XM3,YM3,ZM3 should come from COMMON /SCRUZ/.
+C
+      DIMENSION XM3(LX3,LY3,LZ3,1)
+     $        , YM3(LX3,LY3,LZ3,1)
+     $        , ZM3(LX3,LY3,LZ3,1)
+C
+
+      CALL glmapm1_chk_jac()
+
+      RETURN
+      END
+c------------------------------------------------------------------------
+      subroutine glmapm1_chk_jac()
+c
+C     Routine to generate mapping data based on mesh 1
+C     (Gauss-Legendre Lobatto meshes).
+C
+C         XRM1,  YRM1,  ZRM1   -   dx/dr, dy/dr, dz/dr
+C         XSM1,  YSM1,  ZSM1   -   dx/ds, dy/ds, dz/ds
+C         XTM1,  YTM1,  ZTM1   -   dx/dt, dy/dt, dz/dt
+C         RXM1,  RYM1,  RZM1   -   dr/dx, dr/dy, dr/dz
+C         SXM1,  SYM1,  SZM1   -   ds/dx, ds/dy, ds/dz
+C         TXM1,  TYM1,  TZM1   -   dt/dx, dt/dy, dt/dz
+C         JACM1                -   Jacobian
+C
+C-----------------------------------------------------------------------
+      INCLUDE 'SIZE'
+      INCLUDE 'GEOM'
+      INCLUDE 'INPUT'
+      INCLUDE 'SOLN'
+      include 'PARALLEL'
+
+      include "BAD_ELEMENTS"
+	
+      integer kerr
+      real jacmin,jacmax,dratio
+	  
+C
+C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
+C           share the same array structure in Scratch Common /SCRNS/.
+C
+      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+     $ ,             YRM1(LX1,LY1,LZ1,LELT)
+     $ ,             XSM1(LX1,LY1,LZ1,LELT)
+     $ ,             YSM1(LX1,LY1,LZ1,LELT)
+     $ ,             XTM1(LX1,LY1,LZ1,LELT)
+     $ ,             YTM1(LX1,LY1,LZ1,LELT)
+     $ ,             ZRM1(LX1,LY1,LZ1,LELT)
+      COMMON /CTMP1/ ZSM1(LX1,LY1,LZ1,LELT)
+     $ ,             ZTM1(LX1,LY1,LZ1,LELT)
+C
+      NXY1  = lx1*ly1
+      NYZ1  = ly1*lz1
+      NXYZ1 = lx1*ly1*lz1
+      NTOT1 = NXYZ1*NELT
+C
+      CALL XYZRST (XRM1,YRM1,ZRM1,XSM1,YSM1,ZSM1,XTM1,YTM1,ZTM1,
+     $             IFAXIS)
+C
+
+      IF (ldim.EQ.2) THEN
+         CALL RZERO   (JACM1,NTOT1)
+         CALL ADDCOL3 (JACM1,XRM1,YSM1,NTOT1)
+         CALL SUBCOL3 (JACM1,XSM1,YRM1,NTOT1)
+         CALL COPY    (RXM1,YSM1,NTOT1)
+         CALL COPY    (RYM1,XSM1,NTOT1)
+         CALL CHSIGN  (RYM1,NTOT1)
+         CALL COPY    (SXM1,YRM1,NTOT1)
+         CALL CHSIGN  (SXM1,NTOT1)
+         CALL COPY    (SYM1,XRM1,NTOT1)
+         CALL RZERO   (RZM1,NTOT1)
+         CALL RZERO   (SZM1,NTOT1)
+         CALL RONE    (TZM1,NTOT1)
+      ELSE
+         CALL RZERO   (JACM1,NTOT1)
+         CALL ADDCOL4 (JACM1,XRM1,YSM1,ZTM1,NTOT1)
+         CALL ADDCOL4 (JACM1,XTM1,YRM1,ZSM1,NTOT1)
+         CALL ADDCOL4 (JACM1,XSM1,YTM1,ZRM1,NTOT1)
+         CALL SUBCOL4 (JACM1,XRM1,YTM1,ZSM1,NTOT1)
+         CALL SUBCOL4 (JACM1,XSM1,YRM1,ZTM1,NTOT1)
+         CALL SUBCOL4 (JACM1,XTM1,YSM1,ZRM1,NTOT1)
+         CALL ASCOL5  (RXM1,YSM1,ZTM1,YTM1,ZSM1,NTOT1)
+         CALL ASCOL5  (RYM1,XTM1,ZSM1,XSM1,ZTM1,NTOT1)
+         CALL ASCOL5  (RZM1,XSM1,YTM1,XTM1,YSM1,NTOT1)
+         CALL ASCOL5  (SXM1,YTM1,ZRM1,YRM1,ZTM1,NTOT1)
+         CALL ASCOL5  (SYM1,XRM1,ZTM1,XTM1,ZRM1,NTOT1)
+         CALL ASCOL5  (SZM1,XTM1,YRM1,XRM1,YTM1,NTOT1)
+         CALL ASCOL5  (TXM1,YRM1,ZSM1,YSM1,ZRM1,NTOT1)
+         CALL ASCOL5  (TYM1,XSM1,ZRM1,XRM1,ZSM1,NTOT1)
+         CALL ASCOL5  (TZM1,XRM1,YSM1,XSM1,YRM1,NTOT1)
+      ENDIF
+C
+
+	  call rzero(bad_eg_list,lelg)
+	  call rzero(work_array2,lelg)
+
+      kerr = 0
+	  inje_rank = 0
+      DO 500 ie=1,NELT
+	  
+	     if (minJac.eq.0.0) then
+	  
+         CALL pre_chkjac(JACM1(1,1,1,ie),NXYZ1,ie,xm1(1,1,1,ie),
+     $ ym1(1,1,1,ie),zm1(1,1,1,ie),ldim,ierr)
+         if (ierr.ne.0) kerr = kerr+1
+		 
+         endif
+		 
+	     if (minJac.gt.0.0) then
+
+         dratio = vlmin(JACM1(1,1,1,ie),NXYZ1)/
+     $            vlmax(JACM1(1,1,1,ie),NXYZ1)
+        if (dratio.le.minJac) then
+        
+            ieg = lglel(ie)  ! ieg is the nje global id. need to store it.
+            inje_rank = inje_rank + 1
+			
+			if (inje_rank.gt.nbad_max)  then
+      write(6,*) 'please increase nbad_max to ',inje_rank
+      write(6,*) ' in BAD_ELEMENTS and recompile'
+            endif
+
+            bad_eg_list(ieg) = 1.0
+
+         endif
+		
+         endif
+		 
+  500 CONTINUE
+      kerr = iglsum(kerr,1)
+      nnje_rank = inje_rank
+	  nnje_rank = iglsum(nnje_rank,1)
+
+			if (nnje_rank.gt.nbad_max)  then
+      write(6,*) 'please increase nbad_max to ',nnje_rank
+      write(6,*) ' in BAD_ELEMENTS and recompile'
+            endif
+
+c inje_rank is the bad element number in this rank
+c nnje_rank is the bad elmenet number in all ranks
+
+      if (kerr.gt.0) then
+c         ifxyo = .true.
+c         ifvo  = .false.
+c         ifpo  = .false.
+c         ifto  = .false.
+c         param(66) = 4
+c         call outpost(vx,vy,vz,pr,t,'xyz')
+         if (nid.eq.0) write(6,*) 
+     &  'precheck: Jac error 1 in ',kerr,' elements'
+         ! call exitt
+      endif
+
+      call gop(bad_eg_list,work_array2,'+  ',lelg)
+
+c      call invers2(jacmi,jacm1,ntot1)
+
+      RETURN
+      END
+c-----------------------------------------------------------------------
+      subroutine fix_geom_pre_check ! fix up geometry irregularities
+c
+      include 'SIZE'
+      include 'TOTAL'
+      parameter (lt = lx1*ly1*lz1)
+      common /scrns/ xb(lt,lelt),yb(lt,lelt),zb(lt,lelt)
+      common /scruz/ tmsk(lt,lelt),tmlt(lt,lelt),w1(lt),w2(lt)
+      integer e,f
+      character*3 cb
+      n      = lx1*ly1*lz1*nelt
+      nxyz   = lx1*ly1*lz1
+      nfaces = 2*ldim
+      ifield = 1 ! velocity field
+      if (nelgv.ne.nelgt .or. .not.ifflow) ifield = 2 ! temperature field
+      call rone  (tmlt,n)
+      call dssum (tmlt,lx1,ly1,lz1)  ! denominator
+      call rone  (tmsk,n)
+      do e=1,nelt                ! fill mask where bc is periodic
+      do f=1,nfaces              ! so we don't translate periodic bcs (z only)
+         cb =cbc(f,e,ifield)
+         if (cb.eq.'P  ') call facev (tmsk,e,f,0.0,lx1,ly1,lz1)
+      enddo
+      enddo
+      call dsop(tmsk,'*  ',lx1,ly1,lz1)
+      call dsop(tmsk,'*  ',lx1,ly1,lz1)
+      call dsop(tmsk,'*  ',lx1,ly1,lz1)
+
+      do kpass = 1,ldim+1   ! This doesn't work for 2D, yet.
+                            ! Extra pass is just to test convergence
+c        call opcopy (xb,yb,zb,xm1,ym1,zm1) ! Must use WHOLE field,
+c        call opdssum(xb,yb,zb)             ! not just fluid domain.
+         call copy   (xb,xm1,n)
+         call copy   (yb,ym1,n)
+         call copy   (zb,zm1,n)
+         call dssum  (xb,lx1,ly1,lz1)
+         call dssum  (yb,lx1,ly1,lz1)
+         call dssum  (zb,lx1,ly1,lz1)
+         xm = 0.
+         ym = 0.
+         zm = 0.
+         do e=1,nelt
+            do i=1,nxyz                       ! compute averages of geometry
+               s     = 1./tmlt(i,e)
+               xb(i,e) = s*xb(i,e)
+               yb(i,e) = s*yb(i,e)
+               zb(i,e) = s*zb(i,e)
+               xb(i,e) = xb(i,e) - xm1(i,1,1,e)   ! local displacements
+               yb(i,e) = yb(i,e) - ym1(i,1,1,e)
+               zb(i,e) = zb(i,e) - zm1(i,1,1,e)
+               xb(i,e) = xb(i,e)*tmsk(i,e)
+               yb(i,e) = yb(i,e)*tmsk(i,e)
+               zb(i,e) = zb(i,e)*tmsk(i,e)
+               xm = max(xm,abs(xb(i,e)))
+               ym = max(ym,abs(yb(i,e)))
+               zm = max(zm,abs(zb(i,e)))
+            enddo
+            if (kpass.le.ldim) then
+               call gh_face_extend(xb(1,e),zgm1,lx1,kpass,w1,w2)
+               call gh_face_extend(yb(1,e),zgm1,lx1,kpass,w1,w2)
+               call gh_face_extend(zb(1,e),zgm1,lx1,kpass,w1,w2)
+            endif
+         enddo
+         if (kpass.le.ldim) then
+            call add2(xm1,xb,n)
+            call add2(ym1,yb,n)
+            call add2(zm1,zb,n)
+         endif
+         
+         xx = glamax(xb,n)
+         yx = glamax(yb,n)
+         zx = glamax(zb,n)
+         xm = glmax(xm,1)
+         ym = glmax(ym,1)
+         zm = glmax(zm,1)
+         if (nio.eq.0) write(6,1) xm,ym,zm,xx,yx,zx,kpass
+    1    format(1p6e12.4,' xyz repair',i2)
+      enddo
+      param(59) = 1.       ! ifdef = .true.
+
+c      call geom_reset(1)   ! reset metrics, etc.
+      
+      return
+      end
+c-----------------------------------------------------------------------
+
+      subroutine pre_chkjac(jac,n,iel,X,Y,Z,ND,IERR)
+c
+      include 'SIZE'
+      include 'PARALLEL'
+  
+      include "BAD_ELEMENTS"
+C
+C     Check the array JAC for a change in sign.
+C
+      REAL JAC(N),x(1),y(1),z(1)
+c
+      ierr = 1
+      SIGN = JAC(1)
+      DO 100 I=2,N
+         IF (SIGN*JAC(I).LE.0.0) THEN
+            ieg = lglel(iel)  ! ieg is the nje global id. need to store it.
+            inje_rank = inje_rank + 1
+			
+			if (inje_rank.gt.nbad_max)  then
+      write(6,*) 'please increase nbad_max to ',inje_rank
+      write(6,*) ' in BAD_ELEMENTS and recompile'
+            endif
+		
+            bad_eg_list(ieg) = 1.0
+
+c print error infomation.
+C            WRITE(6,101) nid,I,ieg
+            write(6,*) jac(i-1),jac(i)
+            if (ldim.eq.3) then
+               write(6,7) nid,x(i-1),y(i-1),z(i-1)
+               write(6,7) nid,x(i),y(i),z(i)
+            else
+               write(6,7) nid,x(i-1),y(i-1)
+               write(6,7) nid,x(i),y(i)
+            endif
+    7       format(i5,' xyz:',1p3e14.5)
+c           if (np.eq.1) call out_xyz_el(x,y,z,iel)
+c           ierr=0
+            return
+         ENDIF
+  100 CONTINUE
+C  101 FORMAT(//,i5,2x
+C     $ ,'ERROR:  Vanishing Jacobian near',i7,'th node of element'
+C     $ ,I10,'.')
+c
+c
+      ierr = 0
+      RETURN
+      END
+c-----------------------------------------------------------------------
+      subroutine get_bad_element_list() 
+c read bad_elements.data file
+c but also identify all elements that are close to bad_elements.
+c linear nearby elements as well. 
+c 
+c      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+  
+      include "BAD_ELEMENTS"
+      real dist
+      integer nbe
+
+      call rzero(bad_list,nelt)	  
+      call rzero(bad_xyzr,4*nbad_max)
+      call izero(sbad_eg_list,nbad_max)
+! bad_eg_list convets to sbad_eg_list
+! 
+!      
+      igb = 0
+      do ieg = 1,lelg 
+         if (bad_eg_list(ieg).gt.0.5) then
+	   	 igb=igb+1
+         sbad_eg_list(igb) = ieg
+         endif
+      enddo
+		 
+      nbe = nnje_rank 
+
+      do i =1,nbe
+
+       gbe = sbad_eg_list(i)
+
+       do ie = 1,nelt
+	   eg = lglel(ie) ! return global element number from local element number
+       if(eg.eq.gbe) then  ! if this eg is bad element
+         bad_list(ie) = 1.0
+         ! get center xyz of this element
+		 ! and r (length scale) of this element 
+        call v8center(xc(1,ie),yc(1,ie),zc(1,ie),ecenter)
+        call v8length(xc(1,ie),yc(1,ie),zc(1,ie),elength)
+
+         bad_xyzr(1,i) = ecenter(1)
+         bad_xyzr(2,i) = ecenter(2)
+         bad_xyzr(3,i) = ecenter(3)
+
+         bad_xyzr(4,i) = elength 
+
+       endif
+       enddo
+
+      enddo
+
+      ! call glsum(bad_xyzr,4*nbad_max) ! broadcast to all mpi ranks, this is wrong.
+      call gop(bad_xyzr,work_array,'+  ',4*nbad_max)
+
+       do ie = 1,nelt
+      
+        if (bad_list(ie).eq.0) then
+	
+        call v8center(xc(1,ie),yc(1,ie),zc(1,ie),ecenter)
+        call v8length(xc(1,ie),yc(1,ie),zc(1,ie),elength)
+
+         do i =1,nbe 		 
+           call distance(ecenter,bad_xyzr(1,i),dist)
+           if (dist.lt.(4.0*bad_xyzr(4,i))) then        
+            bad_list(ie) = 1.0
+           endif
+	     enddo
+
+        endif
+       enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine v8_to_e12(v8x,v8y,v8z,e12)
+      real v8x(8),v8y(8),v8z(8)
+      real e12(3,12)
+
+      do i = 1,4
+        i1 = i
+		i2 = i+1
+		if (i2 > 4) i2 = 1
+        e12(1,i) = (v8x(i1) + v8x(i2))/2.0
+        e12(2,i) = (v8y(i1) + v8y(i2))/2.0
+        e12(3,i) = (v8z(i1) + v8z(i2))/2.0
+      enddo
+
+      do i = 5,8
+        i1 = i
+		i2 = i+1
+		if (i2 > 8) i2 = 5
+        e12(1,i) = (v8x(i1) + v8x(i2))/2.0
+        e12(2,i) = (v8y(i1) + v8y(i2))/2.0
+        e12(3,i) = (v8z(i1) + v8z(i2))/2.0
+      enddo
+	  
+	  
+      do i = 1,4
+        i1 = i
+		i2 = i+4
+        e12(1,i+8) = (v8x(i1) + v8x(i2))/2.0
+        e12(2,i+8) = (v8y(i1) + v8y(i2))/2.0
+        e12(3,i+8) = (v8z(i1) + v8z(i2))/2.0
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine v8center(v8x,v8y,v8z,center)
+      real v8x(8),v8y(8),v8z(8)
+      real center(3)
+	  
+      center(1) = 0.0
+      center(2) = 0.0
+      center(3) = 0.0
+       do i = 1,8
+       center(1) =  center(1) + v8x(i)
+       center(2) =  center(2) + v8y(i)
+       center(3) =  center(3) + v8z(i)
+       enddo
+      center(1) = center(1) / 8.0
+      center(2) = center(2) / 8.0
+      center(3) = center(3) / 8.0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine v8length(v8x,v8y,v8z,length)
+      real v8x(8),v8y(8),v8z(8)
+      real v1xyz(3),v2xyz(3)
+      real length,dist
+	  
+      length = 1.0
+      do i = 1,4
+        i1 = i
+		i2 = i+1
+		if (i2 > 4) i2 = 1
+        v1xyz(1) = v8x(i1)
+        v1xyz(2) = v8y(i1)
+        v1xyz(3) = v8z(i1)
+
+        v2xyz(1) = v8x(i2)
+        v2xyz(2) = v8y(i2)
+        v2xyz(3) = v8z(i2)
+		
+        call distance(v1xyz,v2xyz,dist)
+        length = length*dist
+
+      enddo
+
+      do i = 5,8
+        i1 = i
+		i2 = i+1
+		if (i2 > 8) i2 = 5
+        v1xyz(1) = v8x(i1)
+        v1xyz(2) = v8y(i1)
+        v1xyz(3) = v8z(i1)
+
+        v2xyz(1) = v8x(i2)
+        v2xyz(2) = v8y(i2)
+        v2xyz(3) = v8z(i2)
+		
+        call distance(v1xyz,v2xyz,dist)
+        length = length*dist
+      enddo
+	  
+	  
+      do i = 1,4
+        i1 = i
+		i2 = i+4
+        v1xyz(1) = v8x(i1)
+        v1xyz(2) = v8y(i1)
+        v1xyz(3) = v8z(i1)
+
+        v2xyz(1) = v8x(i2)
+        v2xyz(2) = v8y(i2)
+        v2xyz(3) = v8z(i2)
+		
+        call distance(v1xyz,v2xyz,dist)
+        length = length*dist
+      enddo
+
+       length = length**(1.0/12.0)
+
+      return
+      end
+!----------------------------------------------------------------
+      subroutine distance(a,b,d)
+      real d,a(3),b(3)
+      d = sqrt((a(1)-b(1))**2.0+(a(2)-b(2))**2.0+(a(3)-b(3))**2.0)
+      return
+      end
+!---------


### PR DESCRIPTION
This PR adds a new nekRS model developed for the HTTF lower plenum to study the related flow mixing phenomenon. 
- New set of boundary conditions are investigated, particularly more inlet channel groups are considered in the new model; 
- Improved inlet boundary conditions are developed by adopting the solution profiles from a fully developed turbulent pipe case;
- Detailed guidelines as to how to specify the detailed boundary conditions with nekRS; 
- CFD mesh files as well as high-quality figures are provided using github LFS to minimize PR file size. 