### PR TITLE
Fixed failing test caused by quotations around number. Ref #0000.

### DIFF
--- a/msr/lotus/steady_state/run_neutronics_9_group.i
+++ b/msr/lotus/steady_state/run_neutronics_9_group.i
@@ -40,8 +40,7 @@
     new_boundary = 'reactor_out'
     # Dummy parameter
     normals = '1 0 0'
-    tolerance = '1'
-    variance = '1'
+    normal_tol = 1
   []
   [recreate_outer_part2]
     type = ParsedGenerateSideset


### PR DESCRIPTION
Fixed failing test caused by quotations around number. Ref #0000.

The failing test claim an unused parameter "tolerance". This parameter was deprecated in https://github.com/idaholab/moose/pull/26869. The reason the deprecation didn't work here was because the tolerance parameter is of type `Real`, yet the value on the input file was put in single quotes, changing the type seen by the parser.