### PR TITLE
Set use_shell test param to true for test that needs to be run in shell

### DIFF
--- a/htgr/assembly/tests
+++ b/htgr/assembly/tests
@@ -58,5 +58,6 @@
     type = RunCommand
     command = 'mkdir test_dir; cp assembly.py test_dir/assembly.py; cd test_dir; python assembly.py'
     required_python_packages = 'matplotlib uncertainties h5py'
+    use_shell = true
   []
 []


### PR DESCRIPTION
For `RunCommand` tests that string multiple commands together with semicolons, it is best to set the test parameter `use_shell` to true to ensure proper execution.

Closes #399.