### PR TITLE
Removed extra semicolon from input.

### DIFF
--- a/pbfhr/gFHR/steady/gFHR_griffin_cr_ss.i
+++ b/pbfhr/gFHR/steady/gFHR_griffin_cr_ss.i
@@ -307,7 +307,7 @@ Rho_ref = 1973.8 # kg/m^3
     streamline_points = '0.152  0.60 0  0.152  3.6947 0;
                          0.450  0.60 0  0.450  3.6947 0;
                          0.750  0.60 0  0.750  3.6947 0;
-                         1.050  0.60 0  1.050  3.6947 0;'
+                         1.050  0.60 0  1.050  3.6947 0'
     streamline_segment_subdivisions = '20; 20; 20; 20' # align with the neutronics mesh
 
     # Pebble options


### PR DESCRIPTION
MOOSE has recently been updated so that, when parsing a semicolon-seperated vector of vectors from an input file, a trailing semicolon on the last vector will result in the creation of an additional vector of size zero. This effect is not intended for the gFHR_griffin_cr_ss.i input, so the trailing semicolon has been removed.
refs #381
