### PR TITLE
Fix failure in Blue Crab devel recipe

### DIFF
--- a/microreactors/gcmr/assembly/steady_state/tests
+++ b/microreactors/gcmr/assembly/steady_state/tests
@@ -148,7 +148,7 @@
     executable_pattern = 'blue_crab*'
     cli_args = "MultiApps/active='' Transfers/active=''
                 Problem/restart_file_base='../steady_state/BISON_out_cp/LATEST'
-                Mesh/file='../steady_state/BISON_out_cp/LATEST'
+                Mesh/fmg/file='../steady_state/BISON_out_cp/LATEST'
                 Executioner/num_steps=4"
     prereq = 'bison_alone'
     min_parallel = 4

--- a/microreactors/gcmr/assembly/steady_state/tests
+++ b/microreactors/gcmr/assembly/steady_state/tests
@@ -164,7 +164,7 @@
     executable_pattern = 'blue_crab*'
     cli_args = "MultiApps/active='' Transfers/active=''
                 Problem/restart_file_base='../steady_state/BISON_out_cp/LATEST'
-                Mesh/file='../steady_state/BISON_out_cp/LATEST'
+                Mesh/fmg/file='../steady_state/BISON_out_cp/LATEST'
                 Executioner/num_steps=4"
     prereq = 'bison_alone_transient_syntax'
     min_parallel = 4


### PR DESCRIPTION
Changed FileMeshobject to FileMeshGenerator object

The object that reads the mesh for the `microreactors/gcmr/assembly/steady_state.bison_alone_transient_syntax` test is specified in the cli_args as a FileMesh. However, the input file contains a FileMeshGenerator, which causes conflicts and ultimately, a test crash. This PR changes the FileMesh in the cli_args to a FileMeshGenerator to be consistent with what is provided in the input file.

Closes #526

<!--
STOP!
Did you clear your pull request through your institution export control and publication clearance office?
As soon as the pull request is made, or as soon as you have uploaded the model to a public fork of the virtual test bed,
the model is available to the general public.
- At ANL: PANDA
- At INL: LRS

Did the sponsors for the creation of all or part of this model agree to its dissemination?

This PR must be associated with an issue.
Be sure to reference it by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
Use "closes" if the PR addresses all the important items in the issue.

If the issue does not exist yet, please create it.

If this PR is not ready for review, please create it as a draft.
-->
