### PR TITLE
Removed unused parameters to avoid error. Refs #0.

### DIFF
--- a/microreactors/gcmr/bypass_flow/mesh_bypass.i
+++ b/microreactors/gcmr/bypass_flow/mesh_bypass.i
@@ -8,16 +8,6 @@
 # parameters of the coolant channels
 
 radius_coolant = 0.00635 # m
-length_channel = 2 # m
-channel_n_elems = 50
-
-assembly_height = 2.
-# numbers of channels and assemblies
-
-nb_assembly = 59
-nb_coolant_per_assembly = 18
-nb_fuel_per_assembly = 42
-nb_coolant_tot = '${fparse nb_assembly * nb_coolant_per_assembly}'
 
 # other parameters of the assembly
 


### PR DESCRIPTION
Removed variables from an input file that are no longer used. This is necessary to avoid Pronghorn crashing with unused variable warnings. We need this change to get https://github.inl.gov/ncrc/pronghorn/pull/1295 merged, which is in turn needed to get #555 merged.
