### PR TITLE
Add SS316ElasticityTensor Model Choice Parameter

### DIFF
--- a/microreactors/KRUSTY/Multiphysics_15C_RIT/KRUSTY_BISON_THERMOMECHANICS_TR.i
+++ b/microreactors/KRUSTY/Multiphysics_15C_RIT/KRUSTY_BISON_THERMOMECHANICS_TR.i
@@ -366,6 +366,7 @@ reflector_disp = 1.48e-3 # Corresponding to 15 cents reactivity insertion
   []
   [SS316Mech]
     type = SS316ElasticityTensor
+    elastic_constants_model = legacy_ifr
     block = '${ss_all} ${hp_all}'
     temperature = temp
   []

--- a/microreactors/KRUSTY/Multiphysics_SS/KRUSTY_BISON_THERMOMECHANICS.i
+++ b/microreactors/KRUSTY/Multiphysics_SS/KRUSTY_BISON_THERMOMECHANICS.i
@@ -382,6 +382,7 @@ reflector_disp = 0.0
   [SS316Mech]
     type = SS316ElasticityTensor
     block = '${ss_all} ${hp_all}'
+    elastic_constants_model = legacy_ifr
     temperature = temp
   []
   [SS316Exp]

--- a/microreactors/mrad/triso_failure/UnitCell_with_TM/MP_ss_bison_TM.i
+++ b/microreactors/mrad/triso_failure/UnitCell_with_TM/MP_ss_bison_TM.i
@@ -187,6 +187,7 @@ mod_env_blocks = 'mod_envelope_01 mod_envelope_02 mod_envelope_03 mod_envelope_0
   []
   [elasticity_tensor_SS_envelop]
     type = SS316ElasticityTensor
+    elastic_constants_model = legacy_ifr
     temperature = temp
     block = ${mod_env_blocks}
   []

--- a/sfr/vtr/core_support_plate_3d.i
+++ b/sfr/vtr/core_support_plate_3d.i
@@ -103,6 +103,7 @@ Tref   = 293.15 # reference temperature for the linear thermal expansion for SS3
 [Materials]
   [elasticity_tensor_ss316]
     type = SS316ElasticityTensor
+    elastic_constants_model = legacy_ifr
   []
   [stress]
     type = ComputeLinearElasticStress


### PR DESCRIPTION
Added `elastic_constants_model = legacy_ifr` to SS316ElasticityTensor. This fixes a required parameter error due to a BISON change requiring this new parameter.

Closes #592

<!--
STOP!
Did you clear your pull request through your institution export control and publication clearance office?
As soon as the pull request is made, or as soon as you have uploaded the model to a public fork of the virtual test bed,
the model is available to the general public.
- At ANL: PANDA
- At INL: LRS

Did the sponsors for the creation of all or part of this model agree to its dissemination?

This PR must be associated with an issue.
Be sure to reference it by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
Use "closes" if the PR addresses all the important items in the issue.

If the issue does not exist yet, please create it.

If this PR is not ready for review, please create it as a draft.
-->
