### PR TITLE
Update deprecated syntax in SAM inputs, relax tolerance on HTR-PM loop transient test

### DIFF
--- a/doc/content/htgr/htr-pm/htr-pm_model.md
+++ b/doc/content/htgr/htr-pm/htr-pm_model.md
@@ -146,15 +146,15 @@ Heat transfer in the pebble bed is a complex phenomenon that involves pebble-peb
 
 ### Kernels
 
-The block is used to define the physics of the model. In SAM, the governing equations are essentially divided into the time derivative and spatial terms. The mass equation is modeled using `PMFluidPressureTimeDerivative` and `MDFluidMassKernel` as below:
+The block is used to define the physics of the model. In SAM, the governing equations are essentially divided into the time derivative and spatial terms. The mass equation is modeled using `PINSFEFluidPressureTimeDerivative` and `MDFluidMassKernel` as below:
 
 !listing htgr/htr-pm/ss-main.i block=mass_time mass_space language=cpp
 
-The $x$ and $y$ momentum terms are modeled with `PMFluidVelocityTimeDerivative` and `MDFluidMomentumKernel`. Note that the `component` parameter in `MDFluidMomentumKernel` is defined as `0` and `1` for $x$ and $y$ momentum, respectively.
+The $x$ and $y$ momentum terms are modeled with `PINSFEFluidVelocityTimeDerivative` and `MDFluidMomentumKernel`. Note that the `component` parameter in `MDFluidMomentumKernel` is defined as `0` and `1` for $x$ and $y$ momentum, respectively.
 
 !listing htgr/htr-pm/ss-main.i block=mass_time x_momentum_time x_momentum_space y_momentum_time y_momentum_space language=cpp
 
-Fluid energy is modeled with `PMFluidTemperatureTimeDerivative`, `MDFluidEnergyKernel`, and `PorousMediumEnergyKernel`. The first two model the time derivative and spatial terms of the fluid heat transfer equation while the third models the heat transfer between fluid and solid.
+Fluid energy is modeled with `PINSFEFluidTemperatureTimeDerivative`, `MDFluidEnergyKernel`, and `PorousMediumEnergyKernel`. The first two model the time derivative and spatial terms of the fluid heat transfer equation while the third models the heat transfer between fluid and solid.
 
 !listing htgr/htr-pm/ss-main.i block=temperature_time temperature_space temperature_heat_transfer language=cpp
 

--- a/htgr/htr-pm/plofc-main-transient.i
+++ b/htgr/htr-pm/plofc-main-transient.i
@@ -121,15 +121,15 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
  #######
   [T_reactor_in]
     type = ParsedFunction
-    value = 'T_in'
-    vars = 'T_in'
-    vals = '2Dreceiver_temperature_in'
+    expression = 'T_in'
+    symbol_names = 'T_in'
+    symbol_values = '2Dreceiver_temperature_in'
   []
   [T_core_out]
     type = ParsedFunction
-    value = 'T_out'
-    vars = 'T_out'
-    vals = '2Dreceiver_temperature_out'
+    expression = 'T_out'
+    symbol_names = 'T_out'
+    symbol_values = '2Dreceiver_temperature_out'
   []
 []
 
@@ -333,13 +333,13 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
 [Kernels]
   # mass eq
   [mass_time]
-    type = PMFluidPressureTimeDerivative
+    type = PINSFEFluidPressureTimeDerivative
     variable = p
     porosity = porosity_aux
     block = ${fluid_blocks}
   []
   [mass_space]
-    type = MDFluidMassKernel
+    type = INSFEFluidMassKernel
     variable = p
     porosity = porosity_aux
     block = ${fluid_blocks}
@@ -347,12 +347,12 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
 
   # x-momentum
   [x_momentum_time]
-    type = PMFluidVelocityTimeDerivative
+    type = PINSFEFluidVelocityTimeDerivative
     variable = vel_x
     block = ${fluid_blocks}
   []
   [x_momentum_space]
-    type = MDFluidMomentumKernel
+    type = INSFEFluidMomentumKernel
     variable = vel_x
     porosity = porosity_aux
     component = 0
@@ -361,12 +361,12 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
 
   # y-momentum
   [y_momentum_time]
-    type = PMFluidVelocityTimeDerivative
+    type = PINSFEFluidVelocityTimeDerivative
     variable = vel_y
     block = ${fluid_blocks}
   []
   [y_momentum_space]
-    type = MDFluidMomentumKernel
+    type = INSFEFluidMomentumKernel
     variable = vel_y
     porosity = porosity_aux
     component = 1
@@ -375,13 +375,13 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
 
   # Fluid temperature
   [temperature_time]
-    type = PMFluidTemperatureTimeDerivative
+    type = PINSFEFluidTemperatureTimeDerivative
     variable = T
     porosity = porosity_aux
     block = ${fluid_blocks}
   []
   [temperature_space]
-    type = MDFluidEnergyKernel
+    type = INSFEFluidEnergyKernel
     variable = T
     porosity = porosity_aux
     block = ${fluid_blocks}
@@ -487,7 +487,7 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
 [BCs]
   # Inlet BCs
   [BC_inlet_mass]
-    type = MDFluidMassBC
+    type = INSFEFluidMassBC
     boundary = 'core_inlet'
     variable = p
     pressure = p
@@ -728,7 +728,7 @@ pbed_d      = 3.0  # Pebble bed diameter (m)
   []
   [dpdz_core]
     type = ParsedPostprocessor
-    function = 'core_pressure_out / 13.9 - core_pressure_in / 13.9'
+    expression = 'core_pressure_out / 13.9 - core_pressure_in / 13.9'
     pp_names = 'core_pressure_out core_pressure_in'
     execute_on = 'INITIAL TIMESTEP_END'
   []

--- a/htgr/htr-pm/plofc-primary-loop-ss.i
+++ b/htgr/htr-pm/plofc-primary-loop-ss.i
@@ -393,7 +393,7 @@ p_outlet          = 7.0e+6 # Reactor outlet pressure (Pa)
   []
   [core_top_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
+    expression = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
     pp_names = 'cold_plenum_outlet_pipe_flow rho_cold_plenum_inlet_pipe_inlet'
   []
 
@@ -439,7 +439,7 @@ p_outlet          = 7.0e+6 # Reactor outlet pressure (Pa)
   []
   [core_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
+    expression = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
     pp_names = 'core_flow hot_plenum_inlet_pipe_rho'
   []
 

--- a/htgr/htr-pm/plofc-primary-loop-transient.i
+++ b/htgr/htr-pm/plofc-primary-loop-transient.i
@@ -398,7 +398,7 @@ p_outlet          = 7.0e+6 # Reactor outlet pressure (Pa)
   []
   [core_top_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
+    expression = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
     pp_names = 'cold_plenum_outlet_pipe_flow rho_cold_plenum_inlet_pipe_inlet'
   []
 
@@ -444,7 +444,7 @@ p_outlet          = 7.0e+6 # Reactor outlet pressure (Pa)
   []
   [core_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
+    expression = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
     pp_names = 'core_flow hot_plenum_inlet_pipe_rho'
   []
 

--- a/htgr/htr-pm/plofc-rccs-water-transient.i
+++ b/htgr/htr-pm/plofc-rccs-water-transient.i
@@ -17,11 +17,7 @@ Dh_pipe           = 2
   global_init_T = ${T_inlet_rccs}
   Tsolid_sf = 1e-5
   scaling_factor_var = '1 1e-3 1e-6'
-
-  [PBModelParams]
-    pbm_scaling_factors = '1 1e-3 1e-6'
-    p_order = 1
-  []
+  p_order = 1
 []
 
 [Problem]
@@ -69,8 +65,8 @@ Dh_pipe           = 2
     type = ParsedAux
     block = 'rccs-panel:hs0'
     variable = QRad_multiplied
-    args = 'QRad'
-    function = 'QRad * 18.84955592 / 26.452210 ' #  Multiplier = (2 * PI * r_rpv_outer) / (2 * PI * r_rccs_panel_inner) --> Qrad_rpv * area_rpv = Qrad_rccs * area_rccs_inner
+    coupled_variables = 'QRad'
+    expression = 'QRad * 18.84955592 / 26.452210 ' #  Multiplier = (2 * PI * r_rpv_outer) / (2 * PI * r_rccs_panel_inner) --> Qrad_rpv * area_rpv = Qrad_rccs * area_rccs_inner
     execute_on = 'timestep_end'
   []
 []

--- a/htgr/htr-pm/ss-main.i
+++ b/htgr/htr-pm/ss-main.i
@@ -115,15 +115,15 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
  #######
   [T_reactor_in]
     type = ParsedFunction
-    value = 'T_in'
-    vars = 'T_in'
-    vals = '2Dreceiver_temperature_in'
+    expression = 'T_in'
+    symbol_names = 'T_in'
+    symbol_values = '2Dreceiver_temperature_in'
   []
   [T_core_out]
     type = ParsedFunction
-    value = 'T_out'
-    vars = 'T_out'
-    vals = '2Dreceiver_temperature_out'
+    expression = 'T_out'
+    symbol_names = 'T_out'
+    symbol_values = '2Dreceiver_temperature_out'
   []
 []
 
@@ -327,13 +327,13 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
 [Kernels]
   # mass eq
   [mass_time]
-    type = PMFluidPressureTimeDerivative
+    type = PINSFEFluidPressureTimeDerivative
     variable = p
     porosity = porosity_aux
     block = ${fluid_blocks}
   []
   [mass_space]
-    type = MDFluidMassKernel
+    type = INSFEFluidMassKernel
     variable = p
     porosity = porosity_aux
     block = ${fluid_blocks}
@@ -341,12 +341,12 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
 
   # x-momentum
   [x_momentum_time]
-    type = PMFluidVelocityTimeDerivative
+    type = PINSFEFluidVelocityTimeDerivative
     variable = vel_x
     block = ${fluid_blocks}
   []
   [x_momentum_space]
-    type = MDFluidMomentumKernel
+    type = INSFEFluidMomentumKernel
     variable = vel_x
     porosity = porosity_aux
     component = 0
@@ -355,12 +355,12 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
 
   # y-momentum
   [y_momentum_time]
-    type = PMFluidVelocityTimeDerivative
+    type = PINSFEFluidVelocityTimeDerivative
     variable = vel_y
     block = ${fluid_blocks}
   []
   [y_momentum_space]
-    type = MDFluidMomentumKernel
+    type = INSFEFluidMomentumKernel
     variable = vel_y
     porosity = porosity_aux
     component = 1
@@ -369,13 +369,13 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
 
   # Fluid temperature
   [temperature_time]
-    type = PMFluidTemperatureTimeDerivative
+    type = PINSFEFluidTemperatureTimeDerivative
     variable = T
     porosity = porosity_aux
     block = ${fluid_blocks}
   []
   [temperature_space]
-    type = MDFluidEnergyKernel
+    type = INSFEFluidEnergyKernel
     variable = T
     porosity = porosity_aux
     block = ${fluid_blocks}
@@ -493,7 +493,7 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
 [BCs]
   # Inlet BCs
   [BC_inlet_mass]
-    type = MDFluidMassBC
+    type = INSFEFluidMassBC
     boundary = 'core_inlet'
     variable = p
     pressure = p
@@ -734,7 +734,7 @@ rho_in            = 6.3306  # Helium density at 7 MPa and 523.15 K (from NIST)
   []
   [dpdz_core]
     type = ParsedPostprocessor
-    function = 'core_pressure_out / 13.9 - core_pressure_in / 13.9'
+    expression = 'core_pressure_out / 13.9 - core_pressure_in / 13.9'
     pp_names = 'core_pressure_out core_pressure_in'
     execute_on = 'INITIAL TIMESTEP_END'
   []

--- a/htgr/htr-pm/ss-primary-loop-full.i
+++ b/htgr/htr-pm/ss-primary-loop-full.i
@@ -381,7 +381,7 @@ pump_head         = 2.35e6 # Pump head during steady state
     K = '7500 7500'
     K_reverse = '7500 7500'
     Area = 2.2242476
-    Head_fn   = f_pump_head
+    Head = f_pump_head
   []
   [pump_outlet_pipe]
     type           = PBOneDFluidComponent
@@ -576,7 +576,7 @@ pump_head         = 2.35e6 # Pump head during steady state
   []
   [core_top_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
+    expression = 'cold_plenum_outlet_pipe_flow / rho_cold_plenum_inlet_pipe_inlet / 7.068583471'
     pp_names = 'cold_plenum_outlet_pipe_flow rho_cold_plenum_inlet_pipe_inlet'
   []
 
@@ -622,7 +622,7 @@ pump_head         = 2.35e6 # Pump head during steady state
   []
   [core_velocity_scaled]
     type = ParsedPostprocessor
-    function = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
+    expression = 'core_flow / hot_plenum_inlet_pipe_rho / 7.068583471'
     pp_names = 'core_flow hot_plenum_inlet_pipe_rho'
   []
 

--- a/htgr/htr-pm/ss-rccs-water.i
+++ b/htgr/htr-pm/ss-rccs-water.i
@@ -17,11 +17,7 @@ Dh_pipe           = 2 #1
   global_init_T = ${T_inlet_rccs}
   Tsolid_sf = 1e-5
   scaling_factor_var = '1 1e-3 1e-6'
-
-  [PBModelParams]
-    pbm_scaling_factors = '1 1e-3 1e-6'
-    p_order = 1
-  []
+  p_order = 1
 []
 
 [Functions]
@@ -64,8 +60,8 @@ Dh_pipe           = 2 #1
     type = ParsedAux
     block = 'rccs-panel:hs0'
     variable = QRad_multiplied
-    args = 'QRad'
-    function = 'QRad * 18.84955592 / 26.452210 ' #  Multiplier = (2 * PI * r_rpv_outer) / (2 * PI * r_rccs_panel_inner) --> Qrad_rpv * area_rpv = Qrad_rccs * area_rccs_inner
+    coupled_variables = 'QRad'
+    expression = 'QRad * 18.84955592 / 26.452210 ' #  Multiplier = (2 * PI * r_rpv_outer) / (2 * PI * r_rccs_panel_inner) --> Qrad_rpv * area_rpv = Qrad_rccs * area_rccs_inner
     execute_on = 'timestep_end'
   []
 []

--- a/htgr/htr-pm/tests
+++ b/htgr/htr-pm/tests
@@ -143,7 +143,7 @@
     executable_pattern = 'sam*|blue_crab*'
     cli_args = '--app SamApp --allow-unused Executioner/dt=0.005 Problem/restart_file_base=plofc-primary-loop-ss_checkpoint_cp/0002 Executioner/num_steps=2 Executioner/nl_rel_tol=1e-8 Executioner/nl_abs_tol=1e-7'
     abs_zero = 1e-5
-    rel_err = 1e-4
+    rel_err = 5e-3
     max_time = 1000
     method = 'opt'
   []

--- a/microreactors/gcmr/core/Multiphysics/depressurization/MP_SAM_dp.i
+++ b/microreactors/gcmr/core/Multiphysics/depressurization/MP_SAM_dp.i
@@ -187,8 +187,8 @@ layers = 40 # Make sure the number of axial divisions in the fluid domain and so
   [scale_htc]
     type = ParsedAux
     variable = h_scaled
-    function = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
-    args = htc
+    expression = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
+    coupled_variables = htc
   []
   [Tfluid_trans]
     type = SpatialUserObjectAux

--- a/microreactors/gcmr/core/Multiphysics/null_transient/MP_SAM_trN.i
+++ b/microreactors/gcmr/core/Multiphysics/null_transient/MP_SAM_trN.i
@@ -156,8 +156,8 @@ layers = 40 # Make sure the number of axial divisions in the fluid domain and so
   [scale_htc]
     type = ParsedAux
     variable = h_scaled
-    function = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
-    args = htc
+    expression = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
+    coupled_variables = htc
   []
   [Tfluid_trans]
     type = SpatialUserObjectAux

--- a/microreactors/gcmr/core/Multiphysics/single_channel_blockage/MP_SAM_scb.i
+++ b/microreactors/gcmr/core/Multiphysics/single_channel_blockage/MP_SAM_scb.i
@@ -156,8 +156,8 @@ layers = 40 # Make sure the number of axial divisions in the fluid domain and so
   [scale_htc]
     type = ParsedAux
     variable = h_scaled
-    function = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
-    args = htc
+    expression = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
+    coupled_variables = htc
   []
   [Tfluid_trans]
     type = SpatialUserObjectAux

--- a/microreactors/gcmr/core/Multiphysics/steady_state/MP_SAM_ss.i
+++ b/microreactors/gcmr/core/Multiphysics/steady_state/MP_SAM_ss.i
@@ -156,8 +156,8 @@ layers = 40 # Make sure the number of axial divisions in the fluid domain and so
   [scale_htc]
     type = ParsedAux
     variable = h_scaled
-    function = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
-    args = htc
+    expression = '1*htc' # 1 is replaced with the cli_args parameter in its parent app
+    coupled_variables =  htc
   []
   [Tfluid_trans]
     type = SpatialUserObjectAux

--- a/pbfhr/mark1/plant/ss2_primary.i
+++ b/pbfhr/mark1/plant/ss2_primary.i
@@ -909,7 +909,7 @@ area_inlet = 0.33911699112746213
   []
   [Core_inlet_mdot]
     type = ParsedPostprocessor
-    function = 'Core_inlet_rho * Core_inlet_v * ${area_inlet}'
+    expression =  'Core_inlet_rho * Core_inlet_v * ${area_inlet}'
     pp_names = 'Core_inlet_rho Core_inlet_v'
     execute_on = 'INITIAL TIMESTEP_BEGIN TIMESTEP_END TRANSFER'
   []
@@ -940,7 +940,7 @@ area_inlet = 0.33911699112746213
   []
   [Core_outlet_v]
     type = ParsedPostprocessor
-    function = 'Core_outlet_mdot / Core_outlet_rho'
+    expression =  'Core_outlet_mdot / Core_outlet_rho'
     pp_names = 'Core_outlet_mdot Core_outlet_rho'
     execute_on = 'INITIAL TIMESTEP_BEGIN TIMESTEP_END TRANSFER'
   []

--- a/sfr/abtr/abtr_ss.i
+++ b/sfr/abtr/abtr_ss.i
@@ -219,7 +219,7 @@
     fuel_doppler_axial_weight = '6.00E-02  6.00E-02  6.00E-02  6.00E-02  5.50E-02  5.50E-02  5.50E-02  5.50E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.10E-02  3.10E-02  3.10E-02  3.10E-02'
 
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH1_fuel_axial_reactivity_fn
   []
@@ -325,7 +325,7 @@
     fuel_doppler_coef = -1.432E-03
     fuel_doppler_axial_weight = '6.00E-02  6.00E-02  6.00E-02  6.00E-02  5.50E-02  5.50E-02  5.50E-02  5.50E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.10E-02  3.10E-02  3.10E-02  3.10E-02'
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH2_fuel_axial_reactivity_fn
   []
@@ -429,7 +429,7 @@
     fuel_doppler_coef = -2.624E-04
     fuel_doppler_axial_weight = '5.80E-02  5.80E-02  5.80E-02  5.80E-02  5.40E-02  5.40E-02  5.40E-02  5.40E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.40E-02  3.40E-02  3.40E-02  3.40E-02'
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH3_fuel_axial_reactivity_fn
   []
@@ -533,7 +533,7 @@
     fuel_doppler_coef = -1.050E-03
     fuel_doppler_axial_weight = '5.20E-02  5.20E-02  5.20E-02  5.20E-02  5.60E-02  5.60E-02  5.60E-02  5.60E-02  5.90E-02  5.90E-02  5.90E-02  5.90E-02  4.90E-02  4.90E-02  4.90E-02  4.90E-02  3.40E-02  3.40E-02  3.40E-02  3.40E-02'
     # Fuel axial expansion feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH4_fuel_axial_reactivity_fn
   []
@@ -1140,7 +1140,7 @@
   []
   [feedback-Axial]
     type = ParsedPostprocessor
-    function = 'CH1_Fuel_Axial_Expansion_Reactivity+CH2_Fuel_Axial_Expansion_Reactivity+CH3_Fuel_Axial_Expansion_Reactivity+CH4_Fuel_Axial_Expansion_Reactivity'
+    expression = 'CH1_Fuel_Axial_Expansion_Reactivity+CH2_Fuel_Axial_Expansion_Reactivity+CH3_Fuel_Axial_Expansion_Reactivity+CH4_Fuel_Axial_Expansion_Reactivity'
     pp_names = 'CH1_Fuel_Axial_Expansion_Reactivity CH2_Fuel_Axial_Expansion_Reactivity CH3_Fuel_Axial_Expansion_Reactivity CH4_Fuel_Axial_Expansion_Reactivity'
   []
   [feedback-doppler]

--- a/sfr/abtr/abtr_ulof.i
+++ b/sfr/abtr/abtr_ulof.i
@@ -1122,8 +1122,7 @@
   []
 
   [DHX_heatremoval]
-    type = HeatExchangerHeatRe
-    movalRate
+    type = HeatExchangerHeatRemovalRate
     block = 'DHX:primary_pipe'
     heated_perimeter = '${fparse 2.5944/250e6}'
   []

--- a/sfr/abtr/abtr_ulof.i
+++ b/sfr/abtr/abtr_ulof.i
@@ -221,7 +221,7 @@
     fuel_doppler_axial_weight = '6.00E-02  6.00E-02  6.00E-02  6.00E-02  5.50E-02  5.50E-02  5.50E-02  5.50E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.10E-02  3.10E-02  3.10E-02  3.10E-02'
 
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH1_fuel_axial_reactivity_fn
   []
@@ -327,7 +327,7 @@
     fuel_doppler_coef = -1.432E-03
     fuel_doppler_axial_weight = '6.00E-02  6.00E-02  6.00E-02  6.00E-02  5.50E-02  5.50E-02  5.50E-02  5.50E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.10E-02  3.10E-02  3.10E-02  3.10E-02'
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH2_fuel_axial_reactivity_fn
   []
@@ -431,7 +431,7 @@
     fuel_doppler_coef = -2.624E-04
     fuel_doppler_axial_weight = '5.80E-02  5.80E-02  5.80E-02  5.80E-02  5.40E-02  5.40E-02  5.40E-02  5.40E-02  5.70E-02  5.70E-02  5.70E-02  5.70E-02  4.70E-02  4.70E-02  4.70E-02  4.70E-02  3.40E-02  3.40E-02  3.40E-02  3.40E-02'
     # Fuel axial expansion reactivity feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH3_fuel_axial_reactivity_fn
   []
@@ -535,7 +535,7 @@
     fuel_doppler_coef = -1.050E-03
     fuel_doppler_axial_weight = '5.20E-02  5.20E-02  5.20E-02  5.20E-02  5.60E-02  5.60E-02  5.60E-02  5.60E-02  5.90E-02  5.90E-02  5.90E-02  5.90E-02  4.90E-02  4.90E-02  4.90E-02  4.90E-02  3.40E-02  3.40E-02  3.40E-02  3.40E-02'
     # Fuel axial expansion feedback model
-    fuel_axial_expansion_reactivity_feedback = true
+    pke_axial_feedback = Constrained
     n_layers_axial_expansion = 20
     fuel_axial_expansion_reactivity_fn = CH4_fuel_axial_reactivity_fn
   []
@@ -1122,7 +1122,8 @@
   []
 
   [DHX_heatremoval]
-    type = HeatExchangerHeatRemovalRate
+    type = HeatExchangerHeatRe
+    movalRate
     block = 'DHX:primary_pipe'
     heated_perimeter = '${fparse 2.5944/250e6}'
   []
@@ -1138,7 +1139,7 @@
   []
   [feedback-Axial]
     type = ParsedPostprocessor
-    function = 'CH1_Fuel_Axial_Expansion_Reactivity+CH2_Fuel_Axial_Expansion_Reactivity+CH3_Fuel_Axial_Expansion_Reactivity+CH4_Fuel_Axial_Expansion_Reactivity'
+    expression = 'CH1_Fuel_Axial_Expansion_Reactivity+CH2_Fuel_Axial_Expansion_Reactivity+CH3_Fuel_Axial_Expansion_Reactivity+CH4_Fuel_Axial_Expansion_Reactivity'
     pp_names = 'CH1_Fuel_Axial_Expansion_Reactivity CH2_Fuel_Axial_Expansion_Reactivity CH3_Fuel_Axial_Expansion_Reactivity CH4_Fuel_Axial_Expansion_Reactivity'
   []
   [feedback-doppler]


### PR DESCRIPTION
Update deprecated syntax and relax tolerance for HTR-PM loop transient test due to diffs resulting from slight changes in Junction energy balance formulation.

Closes #631 