### PR TITLE
Added option to submodule_updater script to grab and use latest hpc submodules

### DIFF
--- a/scripts/submodule_updater.py
+++ b/scripts/submodule_updater.py
@@ -31,7 +31,7 @@ def parse_args():
     parser.add_argument('--base-remote', default='upstream', help='The base remote, default: \'upstream\'')
 
     parser.add_argument('repo', help='Path to the repository')
-    parser.add_argument('--use-hpc-submodules', action='store_true', help='Whether to update submodule to the latest hpc versions.')
+    parser.add_argument('--use-hpc-submodules', action='store_true', help='Whether to update submodule to the latest HPC versions. This should be run on HPC only.')
     parser.add_argument('submodule:sha1', nargs='?',
                         help='Submodule name and its version to update to. If not specified, `origin/master` or the latest hpc submodule if --use-hpc-submodules is specified.')
 


### PR DESCRIPTION
This updated script was used to create #654. Script output:

```
(moose) [behnpa@rod projects]$ python submodule_updater.py --config-file /data/behnpa/projects/submodule-updater/config.yaml --use-hpc-submodules virtual_test_bed
Looking for hpc submodule version
  - Found hpc sha 8f19da0 for submodule bison
  - Found hpc sha 2a81957 for submodule griffin
  - Found hpc sha 5bb0a44 for submodule pronghorn
  - Could not determine hpc version for SAM. Falling back to default behavior.
  - Found hpc sha bce470d for submodule sockeye
  - Found hpc sha 044b950 for submodule direwolf
  - Found hpc sha 4872187 for submodule bluecrab
  - Found hpc sha 1a0275f for submodule cardinal
  - Could not determine hpc version for relap-7. Falling back to default behavior.
  - Found hpc sha 60f09a2 for submodule moose
  - Found hpc sha 869329b for submodule mastodon
Checking out branch 'submodule_update'
Resetting submodule_update in /data/behnpa/projects/virtual_test_bed to latest upstream/devel
Updating submodules
  - apps/bison to 8f19da0
  - apps/griffin to 2a81957
  - apps/pronghorn to 5bb0a44
  - apps/SAM to origin/master
  - apps/sockeye to bce470d
  - apps/dire_wolf to 044b950
  - apps/blue_crab to 4872187
  - apps/cardinal to 1a0275f
  - apps/relap-7 to origin/master
  - apps/moose to 60f09a2
  - apps/mastodon to 869329b
Pushing 'submodule_update' to github.com:pbehne/virtual_test_bed
Creating PR at github.com/idaholab/virtual_test_bed
Created pull request https://github.com/idaholab/virtual_test_bed/pull/654
```

Refs #0
