### PR TITLE
Removed deprecated use of `use_scalar_variables` in THM

### DIFF
--- a/microreactors/gcmr/balance_of_plant/htgr_load_follow_transient.i
+++ b/microreactors/gcmr/balance_of_plant/htgr_load_follow_transient.i
@@ -621,7 +621,6 @@ eff_turb = 0.843
     position = '${pri_x_core} ${pri_y_core} 0.'
     connections = 'pri_pipe1:out core/coolant_channel:in'
     volume = 1e-3
-    use_scalar_variables = false
   []
 
   [core]
@@ -676,7 +675,6 @@ eff_turb = 0.843
     position = '${pri_x_pipe2} ${pri_y_pipe2} 0.'
     connections = 'core/coolant_channel:out pri_pipe2:in'
     volume = 1e-3
-    use_scalar_variables = false
   []
 
   [pri_pipe2]
@@ -696,7 +694,6 @@ eff_turb = 0.843
       connections = 'pri_pipe2:out pri_pipe3:in pressu/pipe_prz:in'
       position = '${pri_x_pipe3} ${pri_y_pipe3} 0.'
       volume = 1e-3
-      use_scalar_variables = false
     []
     [pipe_prz]
       type = FlowChannel1Phase
@@ -732,7 +729,6 @@ eff_turb = 0.843
     position = '${pri_x_hx} ${pri_y_hx} 0.'
     connections = 'pri_pipe3:out hx/pri:in'
     volume = 1e-3
-    use_scalar_variables = false
   []
 
   [hx]
@@ -795,7 +791,6 @@ eff_turb = 0.843
     position = '${pri_x_pipe4} ${pri_y_pipe4} 0.'
     connections = 'hx/pri:out pri_pipe4:in'
     volume = 1e-3
-    use_scalar_variables = false
   []
 
   [pri_pipe4]
@@ -831,7 +826,6 @@ eff_turb = 0.843
       head = head_fcn
       torque_hydraulic = torque_fcn
       density_rated = ${pump_density_rated}
-      use_scalar_variables = false
     []
 
     [motor]
@@ -930,8 +924,6 @@ eff_turb = 0.843
     speed_cr_fr = 0
     tau_fr_const = 0
     tau_fr_coeff = '0 0 0 0'
-
-    use_scalar_variables = false
   []
 
   # Outlet pipe from the compressor
@@ -1082,8 +1074,6 @@ eff_turb = 0.843
     speed_cr_fr = 0
     tau_fr_const = 0
     tau_fr_coeff = '0 0 0 0'
-
-    use_scalar_variables = false
   []
 
   # Outlet pipe from turbine

--- a/microreactors/gcmr/balance_of_plant/htgr_startup_transient.i
+++ b/microreactors/gcmr/balance_of_plant/htgr_startup_transient.i
@@ -703,7 +703,6 @@ eff_turb = 0.843
     volume = 1e-3
     initial_p = ${pri_press}
     initial_vel_x = ${vel_ini_pri}
-    use_scalar_variables=false
   []
 
   [core]
@@ -764,7 +763,6 @@ eff_turb = 0.843
     volume = 1e-3
     initial_p = ${pri_press}
     initial_vel_x = ${vel_ini_pri}
-    use_scalar_variables=false
   []
 
   [pri_pipe2]
@@ -789,7 +787,6 @@ eff_turb = 0.843
       volume = 1e-3
       initial_p = ${pri_press}
       initial_vel_x = ${vel_ini_pri}
-      use_scalar_variables=false
     []
     [pipe_prz]
       type = FlowChannel1Phase
@@ -833,7 +830,6 @@ eff_turb = 0.843
     volume = 1e-3
     initial_p = ${pri_press}
     initial_vel_x = ${vel_ini_pri}
-    use_scalar_variables=false
   []
 
   [hx]
@@ -904,7 +900,6 @@ eff_turb = 0.843
     volume = 1e-3
     initial_p = ${pri_press}
     initial_vel_x = ${vel_ini_pri}
-    use_scalar_variables=false
   []
 
   [pri_pipe4]
@@ -945,7 +940,6 @@ eff_turb = 0.843
       density_rated = ${pump_density_rated}
       initial_p = ${pri_press}
       initial_vel_x = ${vel_ini_pri}
-      use_scalar_variables=false
     []
 
     [motor]
@@ -1058,8 +1052,6 @@ eff_turb = 0.843
 
     initial_p = ${p_sec}
     initial_vel_x = ${vel_ini_sec}
-
-    use_scalar_variables=false
   []
 
   # Outlet pipe from the compressor
@@ -1228,7 +1220,6 @@ eff_turb = 0.843
 
     initial_p = ${p_sec}
     initial_vel_x = ${vel_ini_sec}
-    use_scalar_variables=false
   []
 
   # Outlet pipe from turbine


### PR DESCRIPTION
This is a pre-req for https://github.com/idaholab/moose/pull/32148.
