### PR TITLE
Changed test output for upcoming Sockeye change

### DIFF
--- a/microreactors/mrad/steady_Na/HPMR_sockeye_ss.i
+++ b/microreactors/mrad/steady_Na/HPMR_sockeye_ss.i
@@ -261,6 +261,7 @@ htc_ext_cond = 1.0e6
   []
   [csv]
     type = CSV
+    show = 'evaporator_boundary_integral condenser_boundary_integral'
     execute_on = 'INITIAL FINAL'
     enable = false
   []

--- a/microreactors/mrad/steady_Na/gold/HPMR_sockeye_ss_csv.csv
+++ b/microreactors/mrad/steady_Na/gold/HPMR_sockeye_ss_csv.csv
@@ -1,3 +1,3 @@
-time,condenser_boundary_integral,evaporator_boundary_integral,heat_pipe:T_avg_wick_ann,heat_pipe:condenser_pool_length,heat_pipe:initial_T_avg_wick_ann,heat_pipe:mass_flow_rate,heat_pipe:mass_total,heat_pipe:mass_vapor,heat_pipe:power_evap,heat_pipe:refill,heat_pipe:rho_liquid_solid_avg,heat_pipe:startup_front,refill,heat_pipe:mass_evap
--50000,0,0,900,0.23272643995262,900.00000000005,0,0.2263450321845,9.7602276270131e-06,0,1,801.70435426404,3,1,0.11329294762363
-0,0,0,900,0.23272643995262,900.00000000005,0,0.2263450321845,9.7602276270131e-06,0,1,801.70435426404,3,1,0.11329294762363
+time,condenser_boundary_integral,evaporator_boundary_integral
+-50000,0,0
+0,0,0


### PR DESCRIPTION
Sockeye will add another PP to its LCVF model: https://github.inl.gov/ncrc/sockeye/pull/905. A CSV test would diff with the new Sockeye version due to lacking the new PP in the gold file, so we restrict the output to only quantities of interest to avoid this.
