### PR TITLE
Griffin changes

### DIFF
--- a/lfr/heterogeneous_single_assembly_3D/neutronics_standalone/neutronics.i
+++ b/lfr/heterogeneous_single_assembly_3D/neutronics_standalone/neutronics.i
@@ -474,6 +474,7 @@ totalpower = 3700000.0 # W
   max_inner_its = 7
 
   cmfd_acceleration = true
+  prolongation_type = additive
   coarse_element_id = coarse_element_id
 []
 

--- a/sfr/abtr_xsgen_workflow/hpc_tests
+++ b/sfr/abtr_xsgen_workflow/hpc_tests
@@ -29,6 +29,7 @@
                 TransportSystems/dfem_sn/NPolar=3
                 Executioner/coarse_element_id=coarse_element_id
                 Executioner/cmfd_eigen_solver_type=krylovshur
+                Executioner/prolongation_type=additive
                 Outputs/csv=true
                 Outputs/checkpoint=false"
     # NOTE: I turned off the checkpoints to see if this solves the timeouts

--- a/sfr/abtr_xsgen_workflow/tests
+++ b/sfr/abtr_xsgen_workflow/tests
@@ -25,6 +25,7 @@
                 TransportSystems/dfem_sn/NPolar=3
                 Executioner/coarse_element_id=coarse_element_id
                 Executioner/cmfd_eigen_solver_type=krylovshur
+                Executioner/prolongation_type=additive
                 GlobalParams/library_file=gold/mcc3xs.xml"
     prereq = 'xs_generation_syntax'
     capabilities = 'method=opt & (griffinapp | bluecrabapp)'


### PR DESCRIPTION
Refs [griffin#3339](https://github.inl.gov/ncrc/griffin/pull/3339).

Due to the default value change, additive prolongation should be explicitly specified.